### PR TITLE
feat: Add `workflow init` command to CLI

### DIFF
--- a/cmd/tdcli/cli.go
+++ b/cmd/tdcli/cli.go
@@ -1165,6 +1165,7 @@ type WorkflowCmd struct {
 	Update   WorkflowUpdateCmd   `kong:"cmd,help='Update workflow'"`
 	Delete   WorkflowDeleteCmd   `kong:"cmd,aliases='rm',help='Delete workflow'"`
 	Start    WorkflowStartCmd    `kong:"cmd,aliases='run',help='Start workflow execution'"`
+	Init     WorkflowInitCmd     `kong:"cmd,help='Create a sample workflow project'"`
 	Attempts WorkflowAttemptsCmd `kong:"cmd,aliases='attempt',help='Workflow attempt management'"`
 	Schedule WorkflowScheduleCmd `kong:"cmd,help='Workflow schedule management'"`
 	Tasks    WorkflowTasksCmd    `kong:"cmd,aliases='task',help='Workflow task management'"`
@@ -1381,6 +1382,15 @@ type WorkflowLogsTaskCmd struct {
 
 func (w *WorkflowLogsTaskCmd) Run(ctx *CLIContext) error {
 	handleWorkflowTaskLog(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, ctx.GlobalFlags)
+	return nil
+}
+
+type WorkflowInitCmd struct {
+	ProjectName string `kong:"arg,help='Name of the new workflow project'"`
+}
+
+func (w *WorkflowInitCmd) Run(ctx *CLIContext) error {
+	handleWorkflowInit(ctx.Context, []string{w.ProjectName}, ctx.GlobalFlags)
 	return nil
 }
 

--- a/cmd/tdcli/workflow_test.go
+++ b/cmd/tdcli/workflow_test.go
@@ -674,3 +674,74 @@ func TestHandleWorkflowProjectCreateArchiveFile(t *testing.T) {
 		t.Errorf("Expected success message, got: %s", outputStr)
 	}
 }
+
+func TestWorkflowInitCmd(t *testing.T) {
+	// Create a temporary directory to run the test in
+	tempDir := t.TempDir()
+	// Change to the temporary directory
+	oldWd, _ := os.Getwd()
+	os.Chdir(tempDir)
+	defer os.Chdir(oldWd)
+
+	projectName := "my-new-workflow"
+	cmd := &WorkflowInitCmd{
+		ProjectName: projectName,
+	}
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Run the command
+	err := cmd.Run(&CLIContext{})
+	if err != nil {
+		t.Fatalf("WorkflowInitCmd.Run() returned an error: %v", err)
+	}
+
+	// Restore stdout and read output
+	w.Close()
+	os.Stdout = oldStdout
+	output, _ := io.ReadAll(r)
+	outputStr := string(output)
+
+	// Verify output message
+	expectedMsg := fmt.Sprintf("Sample workflow project '%s' created successfully", projectName)
+	if !strings.Contains(outputStr, expectedMsg) {
+		t.Errorf("Expected output to contain %q, but got: %s", expectedMsg, outputStr)
+	}
+
+	// Verify directory and files were created
+	// 1. Project directory
+	if _, err := os.Stat(projectName); os.IsNotExist(err) {
+		t.Errorf("Project directory '%s' was not created", projectName)
+	}
+
+	// 2. workflow.dig file
+	digFilePath := filepath.Join(projectName, "workflow.dig")
+	if _, err := os.Stat(digFilePath); os.IsNotExist(err) {
+		t.Errorf("workflow.dig file was not created at %s", digFilePath)
+	}
+
+	// 3. queries subdirectory
+	queriesDirPath := filepath.Join(projectName, "queries")
+	if _, err := os.Stat(queriesDirPath); os.IsNotExist(err) {
+		t.Errorf("queries subdirectory was not created at %s", queriesDirPath)
+	}
+
+	// 4. sample_query.sql file
+	sqlFilePath := filepath.Join(queriesDirPath, "sample_query.sql")
+	if _, err := os.Stat(sqlFilePath); os.IsNotExist(err) {
+		t.Errorf("sample_query.sql file was not created at %s", sqlFilePath)
+	}
+
+	// 5. Verify content of sample_query.sql
+	sqlContent, err := os.ReadFile(sqlFilePath)
+	if err != nil {
+		t.Fatalf("Failed to read sample_query.sql: %v", err)
+	}
+	expectedSQL := "SELECT count(1) FROM www_access;"
+	if !strings.Contains(string(sqlContent), expectedSQL) {
+		t.Errorf("Expected SQL content to contain %q, but got: %s", expectedSQL, string(sqlContent))
+	}
+}

--- a/workflow.go
+++ b/workflow.go
@@ -6,10 +6,14 @@ import (
 	"net/http"
 )
 
+
+
+
 // WorkflowService handles communication with the Workflow related methods of the Treasure Data API.
 type WorkflowService struct {
 	client *Client
 }
+
 
 // Workflow represents a Treasure Data workflow
 type Workflow struct {
@@ -26,16 +30,23 @@ type Workflow struct {
 	Timezone     string                 `json:"timezone"`
 }
 
+
+
+
+
 // WorkflowListOptions specifies optional parameters to Workflow List method
 type WorkflowListOptions struct {
 	Limit  int `url:"limit,omitempty"`
 	Offset int `url:"offset,omitempty"`
 }
 
+
 // WorkflowListResponse represents the response from the workflow list API
 type WorkflowListResponse struct {
 	Workflows []Workflow `json:"workflows"`
 }
+
+
 
 // ListWorkflows returns a list of workflows
 func (s *WorkflowService) ListWorkflows(ctx context.Context, opts *WorkflowListOptions) (*WorkflowListResponse, error) {
@@ -81,6 +92,8 @@ func (s *WorkflowService) GetWorkflow(ctx context.Context, workflowID string) (*
 
 	return &workflow, nil
 }
+
+
 
 // CreateWorkflow creates a new workflow
 func (s *WorkflowService) CreateWorkflow(ctx context.Context, name, project, config string) (*Workflow, error) {

--- a/workflow_attempts_test.go
+++ b/workflow_attempts_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 )
 
+
 func TestWorkflowService_StartWorkflow(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()

--- a/workflow_projects_test.go
+++ b/workflow_projects_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 )
 
+
 func TestWorkflowService_ListProjects(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()

--- a/workflow_schedules_test.go
+++ b/workflow_schedules_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 )
 
+
 func TestWorkflowService_GetWorkflowSchedule(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 )
 
+
 func TestWorkflowService_ListWorkflows(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
@@ -261,6 +262,8 @@ func TestWorkflowService_DeleteWorkflow(t *testing.T) {
 		t.Errorf("Workflows.DeleteWorkflow returned error: %v", err)
 	}
 }
+
+
 
 func TestWorkflowService_ErrorResponse(t *testing.T) {
 	client, mux, teardown := setup()


### PR DESCRIPTION
This change introduces a new command `tdcli workflow init <project-name>` to the command-line interface.

This command creates a new directory with the specified project name and populates it with a sample workflow project structure, including:
- A `workflow.dig` file with a basic workflow definition.
- A `queries` subdirectory.
- A `queries/sample_query.sql` file with a sample query.

This feature makes it easier for you to get started with Treasure Data workflows by providing a simple, ready-to-use template.