### PR TITLE
Add SSL/TLS configuration options to tdcli

### DIFF
--- a/cmd/tdcli/cli.go
+++ b/cmd/tdcli/cli.go
@@ -17,6 +17,12 @@ type CLI struct {
 	Output  string `kong:"help='Output to file'"`
 	Verbose bool   `kong:"short='v',help='Verbose output'"`
 
+	// SSL/TLS Options
+	InsecureSkipVerify bool   `kong:"help='Skip TLS certificate verification',env='TD_INSECURE_SKIP_VERIFY'"`
+	CertFile           string `kong:"help='Client certificate file path',env='TD_CERT_FILE'"`
+	KeyFile            string `kong:"help='Client private key file path',env='TD_KEY_FILE'"`
+	CAFile             string `kong:"help='Custom CA certificate file path',env='TD_CA_FILE'"`
+
 	// Commands
 	Version   VersionCmd   `kong:"cmd,help='Show version'"`
 	Config    ConfigCmd    `kong:"cmd,help='Configuration management'"`
@@ -530,17 +536,21 @@ func (i *ImportPartsCmd) Run(ctx *CLIContext) error {
 
 // Flags struct for compatibility with existing handlers
 type Flags struct {
-	APIKey      string
-	Region      string
-	Format      string
-	Output      string
-	Verbose     bool
-	Database    string
-	Status      string
-	Priority    int
-	Limit       int
-	WithDetails bool
-	Engine      string
+	APIKey             string
+	Region             string
+	Format             string
+	Output             string
+	Verbose            bool
+	Database           string
+	Status             string
+	Priority           int
+	Limit              int
+	WithDetails        bool
+	Engine             string
+	InsecureSkipVerify bool
+	CertFile           string
+	KeyFile            string
+	CAFile             string
 }
 
 // Context structure for command execution
@@ -1926,15 +1936,19 @@ func (w *WorkflowProjectsHooksTestCmd) Run(ctx *CLIContext) error {
 // Convert Kong CLI to legacy Flags structure for compatibility
 func (cli *CLI) ToFlags() Flags {
 	return Flags{
-		APIKey:      cli.APIKey,
-		Region:      cli.Region,
-		Format:      cli.Format,
-		Output:      cli.Output,
-		Verbose:     cli.Verbose,
-		Database:    "",    // Will be set by individual commands
-		Status:      "",    // Will be set by individual commands
-		Priority:    0,     // Will be set by individual commands
-		Limit:       0,     // Will be set by individual commands
-		WithDetails: false, // Will be set by individual commands
+		APIKey:             cli.APIKey,
+		Region:             cli.Region,
+		Format:             cli.Format,
+		Output:             cli.Output,
+		Verbose:            cli.Verbose,
+		Database:           "",    // Will be set by individual commands
+		Status:             "",    // Will be set by individual commands
+		Priority:           0,     // Will be set by individual commands
+		Limit:              0,     // Will be set by individual commands
+		WithDetails:        false, // Will be set by individual commands
+		InsecureSkipVerify: cli.InsecureSkipVerify,
+		CertFile:           cli.CertFile,
+		KeyFile:            cli.KeyFile,
+		CAFile:             cli.CAFile,
 	}
 }

--- a/cmd/tdcli/config.go
+++ b/cmd/tdcli/config.go
@@ -12,10 +12,14 @@ import (
 
 // Config represents the CLI configuration
 type Config struct {
-	APIKey string `toml:"api_key"`
-	Region string `toml:"region"`
-	Format string `toml:"format"`
-	Output string `toml:"output"`
+	APIKey             string `toml:"api_key"`
+	Region             string `toml:"region"`
+	Format             string `toml:"format"`
+	Output             string `toml:"output"`
+	InsecureSkipVerify bool   `toml:"insecure_skip_verify"`
+	CertFile           string `toml:"cert_file"`
+	KeyFile            string `toml:"key_file"`
+	CAFile             string `toml:"ca_file"`
 }
 
 // DefaultConfig returns a config with default values
@@ -94,6 +98,19 @@ func mergeConfig(target, source *Config) {
 	if source.Output != "" {
 		target.Output = source.Output
 	}
+	// SSL options - merge boolean and file paths
+	if source.InsecureSkipVerify {
+		target.InsecureSkipVerify = source.InsecureSkipVerify
+	}
+	if source.CertFile != "" {
+		target.CertFile = source.CertFile
+	}
+	if source.KeyFile != "" {
+		target.KeyFile = source.KeyFile
+	}
+	if source.CAFile != "" {
+		target.CAFile = source.CAFile
+	}
 }
 
 // SaveConfig saves configuration to the specified path
@@ -151,6 +168,10 @@ func (c *ConfigShowCmd) Run(ctx *CLIContext) error {
 	fmt.Printf("Region: %s\n", config.Region)
 	fmt.Printf("Format: %s\n", config.Format)
 	fmt.Printf("Output: %s\n", config.Output)
+	fmt.Printf("Skip TLS Verify: %t\n", config.InsecureSkipVerify)
+	fmt.Printf("Client Cert: %s\n", config.CertFile)
+	fmt.Printf("Client Key: %s\n", config.KeyFile)
+	fmt.Printf("CA File: %s\n", config.CAFile)
 
 	fmt.Println("\nConfiguration file locations (in priority order):")
 	for i, path := range GetConfigPaths() {
@@ -166,7 +187,7 @@ func (c *ConfigShowCmd) Run(ctx *CLIContext) error {
 
 // ConfigSetCmd sets a configuration value
 type ConfigSetCmd struct {
-	Key    string `kong:"arg,help='Configuration key (api_key, region, format, output)'"`
+	Key    string `kong:"arg,help='Configuration key (api_key, region, format, output, insecure_skip_verify, cert_file, key_file, ca_file)'"`
 	Value  string `kong:"arg,help='Configuration value'"`
 	Global bool   `kong:"help='Save to global config (~/.tdcli/.tdcli.toml)'"`
 }
@@ -212,6 +233,21 @@ func (c *ConfigSetCmd) Run(ctx *CLIContext) error {
 		config.Format = c.Value
 	case "output":
 		config.Output = c.Value
+	case "insecure_skip_verify":
+		// Parse boolean
+		if c.Value == "true" || c.Value == "1" || c.Value == "yes" {
+			config.InsecureSkipVerify = true
+		} else if c.Value == "false" || c.Value == "0" || c.Value == "no" {
+			config.InsecureSkipVerify = false
+		} else {
+			return fmt.Errorf("invalid boolean value: %s. Use true/false, 1/0, or yes/no", c.Value)
+		}
+	case "cert_file":
+		config.CertFile = c.Value
+	case "key_file":
+		config.KeyFile = c.Value
+	case "ca_file":
+		config.CAFile = c.Value
 	default:
 		return fmt.Errorf("unknown configuration key: %s", c.Key)
 	}
@@ -241,7 +277,7 @@ func (c *ConfigSetCmd) Run(ctx *CLIContext) error {
 
 // ConfigGetCmd gets a configuration value
 type ConfigGetCmd struct {
-	Key string `kong:"arg,help='Configuration key (api_key, region, format, output)'"`
+	Key string `kong:"arg,help='Configuration key (api_key, region, format, output, insecure_skip_verify, cert_file, key_file, ca_file)'"`
 }
 
 func (c *ConfigGetCmd) Run(ctx *CLIContext) error {
@@ -260,6 +296,18 @@ func (c *ConfigGetCmd) Run(ctx *CLIContext) error {
 		value = config.Format
 	case "output":
 		value = config.Output
+	case "insecure_skip_verify":
+		if config.InsecureSkipVerify {
+			value = "true"
+		} else {
+			value = "false"
+		}
+	case "cert_file":
+		value = config.CertFile
+	case "key_file":
+		value = config.KeyFile
+	case "ca_file":
+		value = config.CAFile
 	default:
 		return fmt.Errorf("unknown configuration key: %s", c.Key)
 	}

--- a/cmd/tdcli/main.go
+++ b/cmd/tdcli/main.go
@@ -45,6 +45,7 @@ func main() {
 	regionExplicitlySet := strings.Contains(argsString, "--region") || os.Getenv("TD_REGION") != ""
 	formatExplicitlySet := strings.Contains(argsString, "--format") || os.Getenv("TD_FORMAT") != ""
 	outputExplicitlySet := strings.Contains(argsString, "--output") || os.Getenv("TD_OUTPUT") != ""
+	sslExplicitlySet := strings.Contains(argsString, "--insecure-skip-verify") || strings.Contains(argsString, "--cert-file") || strings.Contains(argsString, "--key-file") || strings.Contains(argsString, "--ca-file") || os.Getenv("TD_INSECURE_SKIP_VERIFY") != "" || os.Getenv("TD_CERT_FILE") != "" || os.Getenv("TD_KEY_FILE") != "" || os.Getenv("TD_CA_FILE") != ""
 
 	// Get command for validation
 	command := ctx.Command()
@@ -60,6 +61,21 @@ func main() {
 	}
 	if !outputExplicitlySet && config.Output != "" {
 		cli.Output = config.Output
+	}
+	// Apply SSL config values if not explicitly set via flags/env
+	if !sslExplicitlySet {
+		if config.InsecureSkipVerify && !cli.InsecureSkipVerify {
+			cli.InsecureSkipVerify = config.InsecureSkipVerify
+		}
+		if cli.CertFile == "" && config.CertFile != "" {
+			cli.CertFile = config.CertFile
+		}
+		if cli.KeyFile == "" && config.KeyFile != "" {
+			cli.KeyFile = config.KeyFile
+		}
+		if cli.CAFile == "" && config.CAFile != "" {
+			cli.CAFile = config.CAFile
+		}
 	}
 
 	// Validate API key for non-version and non-config commands
@@ -89,6 +105,18 @@ func main() {
 		if cli.Region != "" {
 			clientOptions = append(clientOptions, td.WithRegion(cli.Region))
 		}
+		
+		// Apply SSL options if any are configured
+		if cli.InsecureSkipVerify || cli.CertFile != "" || cli.KeyFile != "" || cli.CAFile != "" {
+			sslOptions := td.SSLOptions{
+				InsecureSkipVerify: cli.InsecureSkipVerify,
+				CertFile:           cli.CertFile,
+				KeyFile:            cli.KeyFile,
+				CAFile:             cli.CAFile,
+			}
+			clientOptions = append(clientOptions, td.WithSSLOptions(sslOptions))
+		}
+		
 		client, err = td.NewClient(cli.APIKey, clientOptions...)
 		if err != nil {
 			log.Fatalf("Failed to create client: %v", err)


### PR DESCRIPTION
Add comprehensive SSL/TLS configuration options to the tdcli CLI tool with environment variable and config file support.

### Changes
- Add SSL flags with environment variable support
- Add SSL options to TOML configuration files
- Implement WithSSLOptions client option for TLS configuration
- Support mutual TLS authentication and custom CA certificates
- Follow existing patterns for environment variables and config priority

### SSL Options Added
- `--insecure-skip-verify` (TD_INSECURE_SKIP_VERIFY)
- `--cert-file` (TD_CERT_FILE)
- `--key-file` (TD_KEY_FILE)
- `--ca-file` (TD_CA_FILE)

Fixes #23

🤖 Generated with [Claude Code](https://claude.ai/code)