### PR TITLE
feat: add new API services and fix race condition

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,6 +38,7 @@ var RegionalEndpoints = map[string]string{
 	"eu":    "https://api.eu01.treasuredata.com",
 	"tokyo": "https://api.treasuredata.co.jp",
 	"ap02":  "https://api.ap02.treasuredata.com",
+	"ap03":  "https://api.ap03.treasuredata.com",
 }
 
 // CDP Regional endpoints
@@ -46,6 +47,7 @@ var CDPRegionalEndpoints = map[string]string{
 	"eu":    "https://api-cdp.eu01.treasuredata.com",
 	"tokyo": "https://api-cdp.treasuredata.co.jp",
 	"ap02":  "https://api-cdp.ap02.treasuredata.com",
+	"ap03":  "https://api-cdp.ap03.treasuredata.com",
 }
 
 // Workflow Regional endpoints
@@ -54,6 +56,39 @@ var WorkflowRegionalEndpoints = map[string]string{
 	"eu":    "https://api-workflow.eu01.treasuredata.com",
 	"tokyo": "https://api-workflow.treasuredata.co.jp",
 	"ap02":  "https://api-workflow.ap02.treasuredata.com",
+	"ap03":  "https://api-workflow.ap03.treasuredata.com",
+}
+
+// Personalization Regional endpoints
+var PersonalizationRegionalEndpoints = map[string]string{
+	"us":    "https://us01.p13n.in.treasuredata.com",
+	"eu":    "https://eu01.p13n.in.treasuredata.com",
+	"tokyo": "https://ap01.p13n.in.treasuredata.com",
+	"ap02":  "https://ap02.p13n.in.treasuredata.com",
+}
+
+// LLM Regional endpoints
+var LLMRegionalEndpoints = map[string]string{
+	"us":    "https://llm-api.treasuredata.com",
+	"eu":    "https://llm-api.eu01.treasuredata.com",
+	"tokyo": "https://llm-api.treasuredata.co.jp",
+	"ap02":  "https://llm-api.ap02.treasuredata.com",
+}
+
+// Postback Regional endpoints
+var PostbackRegionalEndpoints = map[string]string{
+	"us":    "https://in.treasuredata.com",
+	"eu":    "https://eu01.in.treasuredata.com",
+	"tokyo": "https://tokyo.in.treasuredata.com",
+	"ap02":  "https://ap02.in.treasuredata.com",
+}
+
+// StreamImport Regional endpoints
+var StreamImportRegionalEndpoints = map[string]string{
+	"us":    "https://api-import.treasuredata.com",
+	"eu":    "https://api-import.eu01.treasuredata.com",
+	"tokyo": "https://api-import.treasuredata.co.jp",
+	"ap02":  "https://api-import.ap02.treasuredata.com",
 }
 
 // TDTime represents a time that can be unmarshaled from Treasure Data's timestamp format
@@ -134,6 +169,18 @@ type Client struct {
 	// Workflow API URL
 	WorkflowURL *url.URL
 
+	// Personalization API URL
+	PersonalizationURL *url.URL
+
+	// LLM API URL
+	LLMURL *url.URL
+
+	// Postback API URL
+	PostbackURL *url.URL
+
+	// Stream Import API URL
+	StreamImportURL *url.URL
+
 	// API key for authentication
 	APIKey string
 
@@ -145,16 +192,20 @@ type Client struct {
 	meter  metric.Meter
 
 	// Services for different API resources
-	Databases   *DatabasesService
-	Tables      *TablesService
-	Jobs        *JobsService
-	Queries     *QueriesService
-	Results     *ResultsService
-	Users       *UsersService
-	Permissions *PermissionsService
-	BulkImport  *BulkImportService
-	CDP         *CDPService
-	Workflow    *WorkflowService
+	Databases       *DatabasesService
+	Tables          *TablesService
+	Jobs            *JobsService
+	Queries         *QueriesService
+	Results         *ResultsService
+	Users           *UsersService
+	Permissions     *PermissionsService
+	BulkImport      *BulkImportService
+	CDP             *CDPService
+	Workflow        *WorkflowService
+	Personalization *PersonalizationService
+	LLM             *LLMService
+	Postback        *PostbackService
+	StreamImport    *StreamImportService
 }
 
 // ClientOption is a function that configures a Client
@@ -205,6 +256,35 @@ func WithRegion(region string) ClientOption {
 			}
 			c.WorkflowURL = u
 		}
+		if p13nEndpoint, ok := PersonalizationRegionalEndpoints[regionLower]; ok {
+			u, err := url.Parse(p13nEndpoint)
+			if err != nil {
+				return fmt.Errorf("invalid personalization regional endpoint for %s: %w", region, err)
+			}
+			c.PersonalizationURL = u
+		}
+		if llmEndpoint, ok := LLMRegionalEndpoints[regionLower]; ok {
+			u, err := url.Parse(llmEndpoint)
+			if err != nil {
+				return fmt.Errorf("invalid LLM regional endpoint for %s: %w", region, err)
+			}
+			c.LLMURL = u
+		}
+		if postbackEndpoint, ok := PostbackRegionalEndpoints[regionLower]; ok {
+			u, err := url.Parse(postbackEndpoint)
+			if err != nil {
+				return fmt.Errorf("invalid postback regional endpoint for %s: %w", region, err)
+			}
+			c.PostbackURL = u
+		}
+		if streamImportEndpoint, ok := StreamImportRegionalEndpoints[regionLower]; ok {
+			u, err := url.Parse(streamImportEndpoint)
+			if err != nil {
+				return fmt.Errorf("invalid stream import regional endpoint for %s: %w", region, err)
+			}
+			c.StreamImportURL = u
+		}
+
 		return nil
 	}
 }
@@ -315,16 +395,24 @@ func NewClient(apiKey string, opts ...ClientOption) (*Client, error) {
 	baseURL, _ := url.Parse(defaultBaseURL)
 	cdpURL, _ := url.Parse(CDPRegionalEndpoints["us"])
 	workflowURL, _ := url.Parse(WorkflowRegionalEndpoints["us"])
+	p13nURL, _ := url.Parse(PersonalizationRegionalEndpoints["us"])
+	llmURL, _ := url.Parse(LLMRegionalEndpoints["us"])
+	postbackURL, _ := url.Parse(PostbackRegionalEndpoints["us"])
+	streamImportURL, _ := url.Parse(StreamImportRegionalEndpoints["us"])
 
 	c := &Client{
 		httpClient: &http.Client{
 			Timeout: defaultTimeout,
 		},
-		BaseURL:     baseURL,
-		CDPURL:      cdpURL,
-		WorkflowURL: workflowURL,
-		APIKey:      apiKey,
-		UserAgent:   "treasuredata-go-sdk/1.0.0",
+		BaseURL:            baseURL,
+		CDPURL:             cdpURL,
+		WorkflowURL:        workflowURL,
+		PersonalizationURL: p13nURL,
+		LLMURL:             llmURL,
+		PostbackURL:        postbackURL,
+		StreamImportURL:    streamImportURL,
+		APIKey:             apiKey,
+		UserAgent:          "treasuredata-go-sdk/1.0.0",
 	}
 
 	// Apply options
@@ -345,6 +433,10 @@ func NewClient(apiKey string, opts ...ClientOption) (*Client, error) {
 	c.BulkImport = &BulkImportService{client: c}
 	c.CDP = &CDPService{client: c}
 	c.Workflow = &WorkflowService{client: c}
+	c.Personalization = &PersonalizationService{client: c}
+	c.LLM = &LLMService{client: c}
+	c.Postback = &PostbackService{client: c}
+	c.StreamImport = &StreamImportService{client: c}
 
 	return c, nil
 }
@@ -482,6 +574,142 @@ func (c *Client) NewCDPJSONAPIRequest(method, urlStr string, body interface{}) (
 // NewWorkflowRequest creates an API request for Workflow endpoints
 func (c *Client) NewWorkflowRequest(method, urlStr string, body interface{}) (*http.Request, error) {
 	u, err := c.WorkflowURL.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf io.ReadWriter
+	if body != nil {
+		buf = new(bytes.Buffer)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		err := enc.Encode(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(method, u.String(), buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("TD1 %s", c.APIKey))
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("Accept", "application/json")
+
+	return req, nil
+}
+
+// NewPersonalizationRequest creates an API request for Personalization endpoints
+func (c *Client) NewPersonalizationRequest(method, urlStr string, body interface{}) (*http.Request, error) {
+	u, err := c.PersonalizationURL.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf io.ReadWriter
+	if body != nil {
+		buf = new(bytes.Buffer)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		err := enc.Encode(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(method, u.String(), buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/vnd.treasuredata.v1+json")
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("TD1 %s", c.APIKey))
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("Accept", "application/vnd.treasuredata.v1+json")
+
+	return req, nil
+}
+
+// NewLLMRequest creates an API request for LLM endpoints
+func (c *Client) NewLLMRequest(method, urlStr string, body interface{}) (*http.Request, error) {
+	u, err := c.LLMURL.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf io.ReadWriter
+	if body != nil {
+		buf = new(bytes.Buffer)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		err := enc.Encode(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(method, u.String(), buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("TD1 %s", c.APIKey))
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("Accept", "application/json")
+
+	return req, nil
+}
+
+// NewPostbackRequest creates an API request for Postback endpoints
+func (c *Client) NewPostbackRequest(method, urlStr string, body interface{}) (*http.Request, error) {
+	u, err := c.PostbackURL.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf io.ReadWriter
+	if body != nil {
+		buf = new(bytes.Buffer)
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		err := enc.Encode(body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(method, u.String(), buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	req.Header.Set("X-TD-Write-Key", c.APIKey)
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Set("Accept", "application/json")
+
+	return req, nil
+}
+
+// NewStreamImportRequest creates an API request for Stream Import endpoints
+func (c *Client) NewStreamImportRequest(method, urlStr string, body interface{}) (*http.Request, error) {
+	u, err := c.StreamImportURL.Parse(urlStr)
 	if err != nil {
 		return nil, err
 	}

--- a/llm.go
+++ b/llm.go
@@ -1,0 +1,232 @@
+package treasuredata
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// LLMService handles communication with the LLM API.
+type LLMService struct {
+	client *Client
+}
+
+// LLMAction represents an AI action in the LLM API
+type LLMAction struct {
+	ID              string            `json:"id"`
+	Type            string            `json:"type"`
+	IntegrationID   string            `json:"integrationId"`
+	PromptID        string            `json:"promptId"`
+	ChatWidgetType  *string           `json:"chatWidgetType,omitempty"`
+	ChatWidgetLabel *string           `json:"chatWidgetLabel,omitempty"`
+	WebhookTextURL  string            `json:"webhookTextUrl"`
+	SlackRequestURL *string           `json:"slackRequestUrl,omitempty"`
+	UITags          []string          `json:"uiTags,omitempty"`
+	Links           map[string]string `json:"links,omitempty"`
+}
+
+// LLMActionListResponse represents the response from listing actions
+type LLMActionListResponse struct {
+	Data  []LLMAction            `json:"data"`
+	Meta  map[string]interface{} `json:"meta,omitempty"`
+	Links map[string]string      `json:"links,omitempty"`
+}
+
+// LLMActionResponse represents a single action response
+type LLMActionResponse struct {
+	Data  LLMAction              `json:"data"`
+	Meta  map[string]interface{} `json:"meta,omitempty"`
+	Links map[string]string      `json:"links,omitempty"`
+}
+
+// LLMChatRequest represents a request to the chat endpoint
+type LLMChatRequest struct {
+	Message string                 `json:"message"`
+	Context map[string]interface{} `json:"context,omitempty"`
+}
+
+// LLMChatResponse represents a response from the chat endpoint
+type LLMChatResponse struct {
+	Response string                 `json:"response"`
+	Context  map[string]interface{} `json:"context,omitempty"`
+}
+
+// LLMIntegration represents an AI integration configuration
+type LLMIntegration struct {
+	ID            string                 `json:"id"`
+	Name          string                 `json:"name"`
+	Type          string                 `json:"type"`
+	Description   string                 `json:"description,omitempty"`
+	Configuration map[string]interface{} `json:"configuration,omitempty"`
+	Status        string                 `json:"status"`
+	CreatedAt     TDTime                 `json:"created_at"`
+	UpdatedAt     TDTime                 `json:"updated_at"`
+}
+
+// LLMIntegrationListResponse represents the response from listing integrations
+type LLMIntegrationListResponse struct {
+	Data  []LLMIntegration       `json:"data"`
+	Meta  map[string]interface{} `json:"meta,omitempty"`
+	Links map[string]string      `json:"links,omitempty"`
+}
+
+// LLMPrompt represents an AI prompt configuration
+type LLMPrompt struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Content     string   `json:"content"`
+	Variables   []string `json:"variables,omitempty"`
+	Status      string   `json:"status"`
+	CreatedAt   TDTime   `json:"created_at"`
+	UpdatedAt   TDTime   `json:"updated_at"`
+}
+
+// LLMPromptListResponse represents the response from listing prompts
+type LLMPromptListResponse struct {
+	Data  []LLMPrompt            `json:"data"`
+	Meta  map[string]interface{} `json:"meta,omitempty"`
+	Links map[string]string      `json:"links,omitempty"`
+}
+
+// LLMProject represents an LLM project
+type LLMProject struct {
+	ID          string                 `json:"id"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	Status      string                 `json:"status"`
+	Settings    map[string]interface{} `json:"settings,omitempty"`
+	CreatedAt   TDTime                 `json:"created_at"`
+	UpdatedAt   TDTime                 `json:"updated_at"`
+}
+
+// LLMProjectListResponse represents the response from listing projects
+type LLMProjectListResponse struct {
+	Data  []LLMProject           `json:"data"`
+	Meta  map[string]interface{} `json:"meta,omitempty"`
+	Links map[string]string      `json:"links,omitempty"`
+}
+
+// ListActions returns a list of available AI actions
+func (s *LLMService) ListActions(ctx context.Context) (*LLMActionListResponse, error) {
+	req, err := s.client.NewLLMRequest("GET", "api/actions", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp LLMActionListResponse
+	_, err = s.client.Do(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// GetAction retrieves a specific action by ID
+func (s *LLMService) GetAction(ctx context.Context, actionID string) (*LLMActionResponse, error) {
+	u := fmt.Sprintf("api/actions/%s", actionID)
+
+	req, err := s.client.NewLLMRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp LLMActionResponse
+	_, err = s.client.Do(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// ExecuteAction executes an AI action with the given input
+func (s *LLMService) ExecuteAction(ctx context.Context, actionID string, input map[string]interface{}) (map[string]interface{}, error) {
+	u := fmt.Sprintf("api/actions/%s/text", actionID)
+
+	req, err := s.client.NewLLMRequest("POST", u, input)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp map[string]interface{}
+	httpResp, err := s.client.Do(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("LLM API returned status %d", httpResp.StatusCode)
+	}
+
+	return resp, nil
+}
+
+// ListIntegrations returns a list of AI integrations
+func (s *LLMService) ListIntegrations(ctx context.Context) (*LLMIntegrationListResponse, error) {
+	req, err := s.client.NewLLMRequest("GET", "api/integrations", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp LLMIntegrationListResponse
+	_, err = s.client.Do(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// ListPrompts returns a list of AI prompts
+func (s *LLMService) ListPrompts(ctx context.Context) (*LLMPromptListResponse, error) {
+	req, err := s.client.NewLLMRequest("GET", "api/prompts", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp LLMPromptListResponse
+	_, err = s.client.Do(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// ListProjects returns a list of LLM projects
+func (s *LLMService) ListProjects(ctx context.Context) (*LLMProjectListResponse, error) {
+	req, err := s.client.NewLLMRequest("GET", "api/projects", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp LLMProjectListResponse
+	_, err = s.client.Do(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// GetProject retrieves a specific LLM project by ID
+func (s *LLMService) GetProject(ctx context.Context, projectID string) (*LLMProject, error) {
+	u := fmt.Sprintf("api/projects/%s", projectID)
+
+	req, err := s.client.NewLLMRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		Data LLMProject `json:"data"`
+	}
+	_, err = s.client.Do(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp.Data, nil
+}

--- a/otel/final_performance_validation.go
+++ b/otel/final_performance_validation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -366,7 +367,7 @@ func (pv *PerformanceValidator) measureThroughput(ctx context.Context, manager *
 	meter := manager.GetMeter()
 	counter, _ := meter.Int64Counter("throughput_test_counter")
 
-	var totalOps int64
+	var totalOps atomic.Int64
 	var wg sync.WaitGroup
 	stopCh := make(chan struct{})
 
@@ -379,7 +380,7 @@ func (pv *PerformanceValidator) measureThroughput(ctx context.Context, manager *
 			for {
 				select {
 				case <-stopCh:
-					totalOps += ops
+					totalOps.Add(ops)
 					return
 				default:
 					// Perform a typical operation
@@ -403,7 +404,7 @@ func (pv *PerformanceValidator) measureThroughput(ctx context.Context, manager *
 	close(stopCh)
 	wg.Wait()
 
-	return totalOps
+	return totalOps.Load()
 }
 
 // Cleanup cleans up the validator resources

--- a/personalization.go
+++ b/personalization.go
@@ -1,0 +1,100 @@
+package treasuredata
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// PersonalizationService handles communication with the Personalization API.
+type PersonalizationService struct {
+	client *Client
+}
+
+// PersonalizationEvent represents an event sent to the personalization API
+type PersonalizationEvent struct {
+	TDClientID      string   `json:"td_client_id,omitempty"`
+	TDURL           string   `json:"td_url,omitempty"`
+	TDPath          string   `json:"td_path,omitempty"`
+	Email           string   `json:"email,omitempty"`
+	ProductName     string   `json:"product_name,omitempty"`
+	ProductCategory string   `json:"product_category,omitempty"`
+	ProductList     []string `json:"product_list,omitempty"`
+	CategoryList    []string `json:"category_list,omitempty"`
+	// Additional attributes can be added dynamically
+}
+
+// PersonalizationToken represents a personalization token configuration
+type PersonalizationToken struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Type        string   `json:"type"`
+	Status      string   `json:"status"`
+	Scopes      []string `json:"scopes,omitempty"`
+	CreatedAt   TDTime   `json:"created_at"`
+	UpdatedAt   TDTime   `json:"updated_at"`
+}
+
+// PersonalizationOffer represents an offer returned by the personalization API
+type PersonalizationOffer struct {
+	Attributes    map[string]interface{}        `json:"attributes,omitempty"`
+	BatchSegments []PersonalizationBatchSegment `json:"batch_segments,omitempty"`
+}
+
+// PersonalizationBatchSegment represents a batch segment in an offer
+type PersonalizationBatchSegment struct {
+	ID string `json:"id"`
+}
+
+// PersonalizationResponse represents the response from the personalization API
+type PersonalizationResponse struct {
+	Offers map[string]PersonalizationOffer `json:"offers,omitempty"`
+}
+
+// SendEvent sends a personalization event and returns matching offers
+func (s *PersonalizationService) SendEvent(ctx context.Context, database, table string, event map[string]interface{}) (*PersonalizationResponse, error) {
+	u := fmt.Sprintf("%s/%s", database, table)
+
+	req, err := s.client.NewPersonalizationRequest("POST", u, event)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp PersonalizationResponse
+	httpResp, err := s.client.Do(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("personalization API returned status %d", httpResp.StatusCode)
+	}
+
+	return &resp, nil
+}
+
+// SendEventWithToken sends a personalization event with a specific token
+func (s *PersonalizationService) SendEventWithToken(ctx context.Context, database, table, token string, event map[string]interface{}) (*PersonalizationResponse, error) {
+	u := fmt.Sprintf("%s/%s", database, table)
+
+	req, err := s.client.NewPersonalizationRequest("POST", u, event)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add WP13n-Token header
+	req.Header.Set("WP13n-Token", token)
+
+	var resp PersonalizationResponse
+	httpResp, err := s.client.Do(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("personalization API returned status %d", httpResp.StatusCode)
+	}
+
+	return &resp, nil
+}

--- a/postback.go
+++ b/postback.go
@@ -1,0 +1,78 @@
+package treasuredata
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// PostbackService handles communication with the Postback API.
+type PostbackService struct {
+	client *Client
+}
+
+// PostbackEvent represents a single event to be sent via the Postback API
+type PostbackEvent struct {
+	// Required identifier fields
+	TDClientID string `json:"td_client_id,omitempty"`
+	Email      string `json:"email,omitempty"`
+
+	// Common event fields
+	TDURL         string `json:"td_url,omitempty"`
+	TDPath        string `json:"td_path,omitempty"`
+	TDHost        string `json:"td_host,omitempty"`
+	TDReferrer    string `json:"td_referrer,omitempty"`
+	TDTITLE       string `json:"td_title,omitempty"`
+	TDDescription string `json:"td_description,omitempty"`
+	TDIp          string `json:"td_ip,omitempty"`
+	TDUserAgent   string `json:"td_user_agent,omitempty"`
+
+	// Custom fields can be added dynamically via map
+}
+
+// PostbackResponse represents the response from the Postback API
+type PostbackResponse struct {
+	Status string `json:"status,omitempty"`
+}
+
+// SendEvent sends a single event to the Postback API
+func (s *PostbackService) SendEvent(ctx context.Context, database, table string, event interface{}) error {
+	u := fmt.Sprintf("postback/v3/event/%s/%s", database, table)
+
+	req, err := s.client.NewPostbackRequest("POST", u, event)
+	if err != nil {
+		return err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("postback API returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// SendEvents sends multiple events to the Postback API
+func (s *PostbackService) SendEvents(ctx context.Context, database, table string, events []interface{}) error {
+	u := fmt.Sprintf("postback/v3/event/%s/%s", database, table)
+
+	req, err := s.client.NewPostbackRequest("POST", u, events)
+	if err != nil {
+		return err
+	}
+
+	resp, err := s.client.Do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("postback API returned status %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/stream_import.go
+++ b/stream_import.go
@@ -1,0 +1,84 @@
+package treasuredata
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+)
+
+// StreamImportService handles communication with the Stream Import API (api-import endpoints).
+type StreamImportService struct {
+	client *Client
+}
+
+// ImportTableOptions represents options for importing data into a table
+type ImportTableOptions struct {
+	Database string
+	Table    string
+	Data     io.Reader
+	Format   string // e.g., "msgpack.gz"
+}
+
+// ImportResponse represents the response from a table import operation
+type ImportResponse struct {
+	Database string `json:"database,omitempty"`
+	Table    string `json:"table,omitempty"`
+	Status   string `json:"status,omitempty"`
+}
+
+// ImportTable imports data into a table using the Stream Import API.
+// Data should be in msgpack.gz format.
+func (s *StreamImportService) ImportTable(ctx context.Context, database, table string, data io.Reader) (*ImportResponse, error) {
+	u := fmt.Sprintf("v3/table/import/%s/%s", database, table)
+
+	// Read data into a buffer since we need to send it as bytes
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, data); err != nil {
+		return nil, fmt.Errorf("failed to read import data: %w", err)
+	}
+
+	req, err := s.client.NewStreamImportRequest("POST", u, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("Content-Encoding", "gzip")
+
+	var resp ImportResponse
+	_, err = s.client.Do(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// ImportTableWithID imports data into a table with a unique ID for deduplication.
+// Data should be in msgpack.gz format.
+func (s *StreamImportService) ImportTableWithID(ctx context.Context, database, table, uniqueID string, data io.Reader) (*ImportResponse, error) {
+	u := fmt.Sprintf("v3/table/import_with_id/%s/%s/%s", database, table, uniqueID)
+
+	// Read data into a buffer since we need to send it as bytes
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, data); err != nil {
+		return nil, fmt.Errorf("failed to read import data: %w", err)
+	}
+
+	req, err := s.client.NewStreamImportRequest("POST", u, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("Content-Encoding", "gzip")
+
+	var resp ImportResponse
+	_, err = s.client.Do(ctx, req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}


### PR DESCRIPTION
## Summary

This PR updates the Go SDK to cover additional Treasure Data APIs based on the latest API documentation (https://docs.treasure.ai/apis).

## Changes

### New API Services
- **Personalization (P13n) API** (`personalization.go`)
  - `SendEvent()` — send personalization events and retrieve matching offers
  - `SendEventWithToken()` — send events with a specific `WP13n-Token` header
  - Regional endpoints for US, EU, Tokyo, AP02

- **LLM API** (`llm.go`)
  - `ListActions()` / `GetAction()` / `ExecuteAction()` — manage AI actions
  - `ListIntegrations()` — list AI integrations
  - `ListPrompts()` — list prompt configurations
  - `ListProjects()` / `GetProject()` — manage LLM projects
  - Regional endpoints for US, EU, Tokyo, AP02

- **Postback API** (`postback.go`)
  - `SendEvent()` — send single event via postback webhook
  - `SendEvents()` — send multiple events
  - Uses `X-TD-Write-Key` authentication header
  - Regional endpoints for US, EU, Tokyo, AP02

- **Stream Import API** (`stream_import.go`)
  - `ImportTable()` — import msgpack.gz data into a table
  - `ImportTableWithID()` — import with unique ID for deduplication
  - Regional endpoints for US, EU, Tokyo, AP02

### Client Updates
- Added missing `ap03` region to `RegionalEndpoints`, `CDPRegionalEndpoints`, and `WorkflowRegionalEndpoints`
- `WithRegion()` now auto-configures all new API endpoints
- `NewClient()` initializes all new services by default
- Added request helpers: `NewPersonalizationRequest`, `NewLLMRequest`, `NewPostbackRequest`, `NewStreamImportRequest`

### Bug Fix
- Fixed data race in `otel/final_performance_validation.go` by replacing shared `int64` with `sync/atomic.Int64` in the `measureThroughput` function

## Testing
- `go build ./...` passes
- `go vet ./...` passes
- `go test ./... -race` passes (all packages green)