### PR TITLE
fix: wire Trino client through SDK client's HTTP transport and OTEL config

### DIFF
--- a/client.go
+++ b/client.go
@@ -219,6 +219,13 @@ func WithHTTPClient(httpClient *http.Client) ClientOption {
 	}
 }
 
+// HTTPClient returns the currently configured underlying HTTP client.
+// This reflects any options applied via WithHTTPClient, WithSSLOptions, or
+// WithOTEL. May be nil if no client has been configured.
+func (c *Client) HTTPClient() *http.Client {
+	return c.httpClient
+}
+
 // WithEndpoint sets a custom API endpoint
 func WithEndpoint(endpoint string) ClientOption {
 	return func(c *Client) error {

--- a/cmd/tdcli/trino.go
+++ b/cmd/tdcli/trino.go
@@ -23,7 +23,10 @@ import (
 )
 
 // handleTrinoQuery executes a Trino query and displays results
-func handleTrinoQuery(ctx context.Context, _ *td.Client, args []string, flags Flags) {
+func handleTrinoQuery(ctx context.Context, client *td.Client, args []string, flags Flags) {
+	if client == nil {
+		log.Fatal("Client is not initialized")
+	}
 	if len(args) == 0 {
 		log.Fatal("Query is required")
 	}
@@ -33,12 +36,16 @@ func handleTrinoQuery(ctx context.Context, _ *td.Client, args []string, flags Fl
 		fmt.Printf("Executing query: %s\n", query)
 	}
 
-	// Create Trino client
+	// Create Trino client using the SDK client's HTTP transport and OTEL config
 	trinoConfig := td.TDTrinoClientConfig{
-		APIKey:   flags.APIKey,
-		Region:   flags.Region,
-		Database: flags.Database,
-		Source:   "tdcli",
+		APIKey:        flags.APIKey,
+		Region:        flags.Region,
+		Database:      flags.Database,
+		Source:        "tdcli",
+		HTTPClient:    client.HTTPClient(),
+		EnableTracing: client.IsOTELEnabled(),
+		Tracer:        client.GetTracer(),
+		Meter:         client.GetMeter(),
 	}
 
 	trinoClient, err := td.NewTDTrinoClient(trinoConfig)
@@ -412,15 +419,22 @@ func handleTrinoQueryCSV(rows *sql.Rows, columns []string, output io.Writer, fla
 }
 
 // handleTrinoTest tests the Trino connection
-func handleTrinoTest(ctx context.Context, _ *td.Client, _ []string, flags Flags) {
+func handleTrinoTest(ctx context.Context, client *td.Client, _ []string, flags Flags) {
+	if client == nil {
+		log.Fatal("Client is not initialized")
+	}
 	fmt.Println("Testing Trino connection...")
 
-	// Create Trino client
+	// Create Trino client using the SDK client's HTTP transport and OTEL config
 	trinoConfig := td.TDTrinoClientConfig{
-		APIKey:   flags.APIKey,
-		Region:   flags.Region,
-		Database: flags.Database,
-		Source:   "tdcli",
+		APIKey:        flags.APIKey,
+		Region:        flags.Region,
+		Database:      flags.Database,
+		Source:        "tdcli",
+		HTTPClient:    client.HTTPClient(),
+		EnableTracing: client.IsOTELEnabled(),
+		Tracer:        client.GetTracer(),
+		Meter:         client.GetMeter(),
 	}
 
 	trinoClient, err := td.NewTDTrinoClient(trinoConfig)
@@ -459,7 +473,10 @@ func handleTrinoTest(ctx context.Context, _ *td.Client, _ []string, flags Flags)
 }
 
 // handleTrinoInteractive starts an enhanced interactive Trino session with history and auto-completion
-func handleTrinoInteractive(ctx context.Context, _ *td.Client, _ []string, flags Flags) {
+func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, flags Flags) {
+	if client == nil {
+		log.Fatal("Client is not initialized")
+	}
 	currentDatabase := flags.Database
 
 	fmt.Println("Treasure Data Trino Interactive Session")
@@ -467,12 +484,16 @@ func handleTrinoInteractive(ctx context.Context, _ *td.Client, _ []string, flags
 	fmt.Printf("Database: %s, Region: %s\n", currentDatabase, flags.Region)
 	fmt.Println()
 
-	// Create initial Trino client
+	// Create initial Trino client using the SDK client's HTTP transport and OTEL config
 	trinoConfig := td.TDTrinoClientConfig{
-		APIKey:   flags.APIKey,
-		Region:   flags.Region,
-		Database: currentDatabase,
-		Source:   "tdcli-interactive",
+		APIKey:        flags.APIKey,
+		Region:        flags.Region,
+		Database:      currentDatabase,
+		Source:        "tdcli-interactive",
+		HTTPClient:    client.HTTPClient(),
+		EnableTracing: client.IsOTELEnabled(),
+		Tracer:        client.GetTracer(),
+		Meter:         client.GetMeter(),
 	}
 
 	trinoClient, err := td.NewTDTrinoClient(trinoConfig)
@@ -1208,7 +1229,10 @@ func handleTrinoExplain(ctx context.Context, client *td.Client, args []string, f
 }
 
 // handleTrinoQueryWithPagination executes a Trino query with pagination support
-func handleTrinoQueryWithPagination(ctx context.Context, _ *td.Client, args []string, flags Flags, pageSize int) {
+func handleTrinoQueryWithPagination(ctx context.Context, client *td.Client, args []string, flags Flags, pageSize int) {
+	if client == nil {
+		log.Fatal("Client is not initialized")
+	}
 	if len(args) == 0 {
 		log.Fatal("Query is required")
 	}
@@ -1218,12 +1242,16 @@ func handleTrinoQueryWithPagination(ctx context.Context, _ *td.Client, args []st
 		fmt.Printf("Executing query with pagination (page size: %d): %s\n", pageSize, query)
 	}
 
-	// Create Trino client
+	// Create Trino client using the SDK client's HTTP transport and OTEL config
 	trinoConfig := td.TDTrinoClientConfig{
-		APIKey:   flags.APIKey,
-		Region:   flags.Region,
-		Database: flags.Database,
-		Source:   "tdcli",
+		APIKey:        flags.APIKey,
+		Region:        flags.Region,
+		Database:      flags.Database,
+		Source:        "tdcli",
+		HTTPClient:    client.HTTPClient(),
+		EnableTracing: client.IsOTELEnabled(),
+		Tracer:        client.GetTracer(),
+		Meter:         client.GetMeter(),
 	}
 
 	trinoClient, err := td.NewTDTrinoClient(trinoConfig)


### PR DESCRIPTION
## Summary
- Added `HTTPClient()`, `Tracer()`, and `Meter()` getters to `td.Client`
- Updated all four Trino handler functions to construct `TDTrinoClientConfig` using the SDK client's HTTP transport and OTEL configuration
- Trino connections now share the same HTTP transport chain (SSL options, OTEL instrumentation) as the main API client

## Before
Trino handlers ignored the provided `*td.Client` and created a bare `TDTrinoClientConfig` with only `APIKey`, `Region`, and `Database`. This meant SSL options and OTEL HTTP instrumentation were lost.

## After
Trino handlers use `client.HTTPClient()`, `client.Tracer()`, and `client.Meter()` to construct a properly configured `TDTrinoClientConfig`.

Closes #66