### PR TITLE
fix: unify OTEL instrumentation across all CLI commands

### DIFF
--- a/cmd/tdcli/cdp/common.go
+++ b/cmd/tdcli/cdp/common.go
@@ -32,8 +32,20 @@ type Flags struct {
 	CAFile             string
 }
 
+// CaptureErrors signals handleError to panic instead of calling log.Fatalf.
+// Set by the main package's runHandlerWithErrorCapture when wrapping commands.
+var CaptureErrors = false
+
 // handleError handles errors with optional verbose output
 func handleError(err error, message string, verbose bool) {
+	if err != nil {
+		if CaptureErrors {
+			if verbose {
+				panic(fmt.Errorf("%s: %v", message, err))
+			}
+			panic(err)
+		}
+	}
 	if verbose {
 		if tdErr, ok := err.(*td.ErrorResponse); ok {
 			log.Fatalf("%s: %v (Status: %d, Message: %s)", message, err, tdErr.Response.StatusCode, tdErr.Message)

--- a/cmd/tdcli/cli.go
+++ b/cmd/tdcli/cli.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
+	"github.com/mickeey2525/treasuredata-go-sdk/cmd/tdcli/cdp"
+	"github.com/mickeey2525/treasuredata-go-sdk/cmd/tdcli/workflow"
 	"github.com/mickeey2525/treasuredata-go-sdk/otel"
 )
 
@@ -91,10 +93,16 @@ var captureHandlerErrors = false
 // runHandlerWithErrorCapture wraps handler functions to capture their errors.
 func runHandlerWithErrorCapture(handlerFunc func()) (err error) {
 	originalCaptureMode := captureHandlerErrors
+	originalCDPCapture := cdp.CaptureErrors
+	originalWorkflowCapture := workflow.CaptureErrors
 	captureHandlerErrors = true
+	cdp.CaptureErrors = true
+	workflow.CaptureErrors = true
 
 	defer func() {
 		captureHandlerErrors = originalCaptureMode
+		cdp.CaptureErrors = originalCDPCapture
+		workflow.CaptureErrors = originalWorkflowCapture
 		if r := recover(); r != nil {
 			if e, ok := r.(error); ok {
 				err = e

--- a/cmd/tdcli/command_cdp.go
+++ b/cmd/tdcli/command_cdp.go
@@ -318,7 +318,7 @@ type CDPActivationsCreateCmd struct {
 }
 
 func (c *CDPActivationsCreateCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "cdp.activations.create", []string{c.SegmentID, c.Name}, func() {
 		handleCDPActivationCreate(ctx.Context, ctx.Client, []string{c.SegmentID, c.Name, c.Description, c.Configuration}, ctx.GlobalFlags)
 	})
 }
@@ -332,7 +332,7 @@ type CDPActivationsCreateWithStructCmd struct {
 }
 
 func (c *CDPActivationsCreateWithStructCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "cdp.activations.create_with_struct", []string{c.Name, c.SegmentID}, func() {
 		args := []string{c.Name, c.Type, c.SegmentID, c.Configuration}
 		if c.Description != "" {
 			args = append(args, c.Description)
@@ -346,7 +346,7 @@ type CDPActivationsListCmd struct {
 }
 
 func (c *CDPActivationsListCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "cdp.activations.list", []string{}, func() {
 		handleCDPActivationListWithForce(ctx.Context, ctx.Client, ctx.GlobalFlags, c.Force)
 	})
 }
@@ -358,7 +358,7 @@ type CDPActivationsGetCmd struct {
 }
 
 func (c *CDPActivationsGetCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "cdp.activations.get", []string{c.AudienceID, c.SegmentID, c.ActivationID}, func() {
 		handleCDPActivationGet(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID, c.ActivationID}, ctx.GlobalFlags)
 	})
 }
@@ -763,8 +763,9 @@ type CDPJourneysDuplicateCmd struct {
 }
 
 func (c *CDPJourneysDuplicateCmd) Run(ctx *CLIContext) error {
-	handleCDPJourneyDuplicate(ctx.Context, ctx.Client, []string{c.RequestFile}, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "cdp.journeys.duplicate", []string{}, func() {
+		handleCDPJourneyDuplicate(ctx.Context, ctx.Client, []string{c.RequestFile}, ctx.GlobalFlags)
+	})
 }
 
 type CDPJourneysPauseCmd struct {
@@ -772,8 +773,9 @@ type CDPJourneysPauseCmd struct {
 }
 
 func (c *CDPJourneysPauseCmd) Run(ctx *CLIContext) error {
-	handleCDPJourneyPause(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "cdp.journeys.pause", []string{c.JourneyID}, func() {
+		handleCDPJourneyPause(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
+	})
 }
 
 type CDPJourneysResumeCmd struct {
@@ -781,8 +783,9 @@ type CDPJourneysResumeCmd struct {
 }
 
 func (c *CDPJourneysResumeCmd) Run(ctx *CLIContext) error {
-	handleCDPJourneyResume(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "cdp.journeys.resume", []string{c.JourneyID}, func() {
+		handleCDPJourneyResume(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
+	})
 }
 
 type CDPJourneysStatisticsCmd struct {
@@ -799,8 +802,9 @@ func (c *CDPJourneysStatisticsCmd) Run(ctx *CLIContext) error {
 	if c.To != "" {
 		args = append(args, "--to", c.To)
 	}
-	handleCDPJourneyStatistics(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "cdp.journeys.statistics", []string{c.JourneyID}, func() {
+		handleCDPJourneyStatistics(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	})
 }
 
 type CDPJourneysCustomersCmd struct {
@@ -811,8 +815,9 @@ type CDPJourneysCustomersCmd struct {
 
 func (c *CDPJourneysCustomersCmd) Run(ctx *CLIContext) error {
 	args := []string{c.JourneyID, fmt.Sprintf("--limit=%d", c.Limit), fmt.Sprintf("--offset=%d", c.Offset)}
-	handleCDPJourneyCustomers(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "cdp.journeys.customers", []string{c.JourneyID}, func() {
+		handleCDPJourneyCustomers(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	})
 }
 
 type CDPJourneysStageCustomersCmd struct {
@@ -824,8 +829,9 @@ type CDPJourneysStageCustomersCmd struct {
 
 func (c *CDPJourneysStageCustomersCmd) Run(ctx *CLIContext) error {
 	args := []string{c.JourneyID, c.StageID, fmt.Sprintf("--limit=%d", c.Limit), fmt.Sprintf("--offset=%d", c.Offset)}
-	handleCDPJourneyStageCustomers(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "cdp.journeys.stage_customers", []string{c.JourneyID, c.StageID}, func() {
+		handleCDPJourneyStageCustomers(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	})
 }
 
 type CDPJourneysConversionSankeyCmd struct {
@@ -929,8 +935,9 @@ type CDPJourneyActivationsCreateCmd struct {
 }
 
 func (c *CDPJourneyActivationsCreateCmd) Run(ctx *CLIContext) error {
-	handleCDPJourneyActivationCreate(ctx.Context, ctx.Client, []string{c.JourneyID, c.RequestFile}, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "cdp.journeys.activations.create", []string{c.JourneyID}, func() {
+		handleCDPJourneyActivationCreate(ctx.Context, ctx.Client, []string{c.JourneyID, c.RequestFile}, ctx.GlobalFlags)
+	})
 }
 
 type CDPJourneyActivationsGetCmd struct {
@@ -939,8 +946,9 @@ type CDPJourneyActivationsGetCmd struct {
 }
 
 func (c *CDPJourneyActivationsGetCmd) Run(ctx *CLIContext) error {
-	handleCDPJourneyActivationGet(ctx.Context, ctx.Client, []string{c.JourneyID, c.ActivationStepID}, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "cdp.journeys.activations.get", []string{c.JourneyID, c.ActivationStepID}, func() {
+		handleCDPJourneyActivationGet(ctx.Context, ctx.Client, []string{c.JourneyID, c.ActivationStepID}, ctx.GlobalFlags)
+	})
 }
 
 type CDPJourneyActivationsUpdateCmd struct {
@@ -950,8 +958,9 @@ type CDPJourneyActivationsUpdateCmd struct {
 }
 
 func (c *CDPJourneyActivationsUpdateCmd) Run(ctx *CLIContext) error {
-	handleCDPJourneyActivationUpdate(ctx.Context, ctx.Client, []string{c.JourneyID, c.ActivationStepID, c.RequestFile}, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "cdp.journeys.activations.update", []string{c.JourneyID, c.ActivationStepID}, func() {
+		handleCDPJourneyActivationUpdate(ctx.Context, ctx.Client, []string{c.JourneyID, c.ActivationStepID, c.RequestFile}, ctx.GlobalFlags)
+	})
 }
 
 // --- Activation Templates ---

--- a/cmd/tdcli/command_databases.go
+++ b/cmd/tdcli/command_databases.go
@@ -11,10 +11,8 @@ type DatabasesCmd struct {
 type DatabasesListCmd struct{}
 
 func (d *DatabasesListCmd) Run(ctx *CLIContext) error {
-	return InstrumentedRun(ctx, "databases.list", []string{}, func(ctx *CLIContext) error {
-		return runHandlerWithErrorCapture(func() {
-			handleDatabaseList(ctx.Context, ctx.Client, ctx.GlobalFlags)
-		})
+	return runInstrumented(ctx, "databases.list", []string{}, func() {
+		handleDatabaseList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -23,10 +21,8 @@ type DatabasesGetCmd struct {
 }
 
 func (d *DatabasesGetCmd) Run(ctx *CLIContext) error {
-	return InstrumentedRun(ctx, "databases.get", []string{d.Name}, func(ctx *CLIContext) error {
-		return runHandlerWithErrorCapture(func() {
-			handleDatabaseGet(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
-		})
+	return runInstrumented(ctx, "databases.get", []string{d.Name}, func() {
+		handleDatabaseGet(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
 	})
 }
 
@@ -35,7 +31,7 @@ type DatabasesCreateCmd struct {
 }
 
 func (d *DatabasesCreateCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "databases.create", []string{d.Name}, func() {
 		handleDatabaseCreate(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
 	})
 }
@@ -45,7 +41,7 @@ type DatabasesDeleteCmd struct {
 }
 
 func (d *DatabasesDeleteCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "databases.delete", []string{d.Name}, func() {
 		handleDatabaseDelete(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
 	})
 }
@@ -55,7 +51,7 @@ type DatabasesUpdateCmd struct {
 }
 
 func (d *DatabasesUpdateCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "databases.update", []string{d.Name}, func() {
 		handleDatabaseUpdate(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_import.go
+++ b/cmd/tdcli/command_import.go
@@ -16,7 +16,7 @@ type ImportCmd struct {
 type ImportListCmd struct{}
 
 func (i *ImportListCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "bulk-import.list", []string{}, func() {
 		handleBulkImportList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
@@ -26,7 +26,7 @@ type ImportGetCmd struct {
 }
 
 func (i *ImportGetCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "bulk-import.get", []string{i.Session}, func() {
 		handleBulkImportGet(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
@@ -38,7 +38,7 @@ type ImportCreateCmd struct {
 }
 
 func (i *ImportCreateCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "bulk-import.create", []string{i.Session, i.Database, i.Table}, func() {
 		handleBulkImportCreate(ctx.Context, ctx.Client, []string{i.Session, i.Database, i.Table}, ctx.GlobalFlags)
 	})
 }
@@ -48,7 +48,7 @@ type ImportDeleteCmd struct {
 }
 
 func (i *ImportDeleteCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "bulk-import.delete", []string{i.Session}, func() {
 		handleBulkImportDelete(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
@@ -60,7 +60,7 @@ type ImportUploadCmd struct {
 }
 
 func (i *ImportUploadCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "bulk-import.upload", []string{i.Session, i.PartName, i.FilePath}, func() {
 		handleBulkImportUpload(ctx.Context, ctx.Client, []string{i.Session, i.PartName, i.FilePath}, ctx.GlobalFlags)
 	})
 }
@@ -70,7 +70,7 @@ type ImportCommitCmd struct {
 }
 
 func (i *ImportCommitCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "bulk-import.commit", []string{i.Session}, func() {
 		handleBulkImportCommit(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
@@ -80,7 +80,7 @@ type ImportPerformCmd struct {
 }
 
 func (i *ImportPerformCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "bulk-import.perform", []string{i.Session}, func() {
 		handleBulkImportPerform(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
@@ -90,7 +90,7 @@ type ImportFreezeCmd struct {
 }
 
 func (i *ImportFreezeCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "bulk-import.freeze", []string{i.Session}, func() {
 		handleBulkImportFreeze(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
@@ -100,7 +100,7 @@ type ImportUnfreezeCmd struct {
 }
 
 func (i *ImportUnfreezeCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "bulk-import.unfreeze", []string{i.Session}, func() {
 		handleBulkImportUnfreeze(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
@@ -110,7 +110,7 @@ type ImportPartsCmd struct {
 }
 
 func (i *ImportPartsCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "bulk-import.parts", []string{i.Session}, func() {
 		handleBulkImportParts(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_jobs.go
+++ b/cmd/tdcli/command_jobs.go
@@ -11,11 +11,9 @@ type JobsListCmd struct {
 }
 
 func (j *JobsListCmd) Run(ctx *CLIContext) error {
-	return InstrumentedRun(ctx, "jobs.list", []string{}, func(ctx *CLIContext) error {
-		return runHandlerWithErrorCapture(func() {
-			ctx.GlobalFlags.Status = j.Status
-			handleJobList(ctx.Context, ctx.Client, ctx.GlobalFlags)
-		})
+	return runInstrumented(ctx, "jobs.list", []string{}, func() {
+		ctx.GlobalFlags.Status = j.Status
+		handleJobList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -24,7 +22,7 @@ type JobsGetCmd struct {
 }
 
 func (j *JobsGetCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "jobs.get", []string{j.JobID}, func() {
 		handleJobGet(ctx.Context, ctx.Client, []string{j.JobID}, ctx.GlobalFlags)
 	})
 }
@@ -34,7 +32,7 @@ type JobsCancelCmd struct {
 }
 
 func (j *JobsCancelCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "jobs.cancel", []string{j.JobID}, func() {
 		handleJobCancel(ctx.Context, ctx.Client, []string{j.JobID}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_permissions.go
+++ b/cmd/tdcli/command_permissions.go
@@ -18,7 +18,7 @@ type PermsPoliciesCmd struct {
 type PermsPoliciesListCmd struct{}
 
 func (p *PermsPoliciesListCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "permissions.policies.list", []string{}, func() {
 		handlePolicyList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
@@ -28,7 +28,7 @@ type PermsPoliciesGetCmd struct {
 }
 
 func (p *PermsPoliciesGetCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "permissions.policies.get", []string{fmt.Sprintf("%d", p.PolicyID)}, func() {
 		handlePolicyGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", p.PolicyID)}, ctx.GlobalFlags)
 	})
 }
@@ -39,7 +39,7 @@ type PermsPoliciesCreateCmd struct {
 }
 
 func (p *PermsPoliciesCreateCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "permissions.policies.create", []string{p.Name}, func() {
 		args := []string{p.Name}
 		if p.Description != "" {
 			args = append(args, p.Description)
@@ -53,7 +53,7 @@ type PermsPoliciesDeleteCmd struct {
 }
 
 func (p *PermsPoliciesDeleteCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "permissions.policies.delete", []string{fmt.Sprintf("%d", p.PolicyID)}, func() {
 		handlePolicyDelete(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", p.PolicyID)}, ctx.GlobalFlags)
 	})
 }
@@ -68,7 +68,7 @@ type PermsGroupsCmd struct {
 type PermsGroupsListCmd struct{}
 
 func (p *PermsGroupsListCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "permissions.groups.list", []string{}, func() {
 		handlePolicyGroupList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
@@ -78,7 +78,7 @@ type PermsGroupsGetCmd struct {
 }
 
 func (p *PermsGroupsGetCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "permissions.groups.get", []string{p.GroupID}, func() {
 		handlePolicyGroupGet(ctx.Context, ctx.Client, []string{p.GroupID}, ctx.GlobalFlags)
 	})
 }
@@ -88,7 +88,7 @@ type PermsGroupsCreateCmd struct {
 }
 
 func (p *PermsGroupsCreateCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "permissions.groups.create", []string{p.Name}, func() {
 		handlePolicyGroupCreate(ctx.Context, ctx.Client, []string{p.Name}, ctx.GlobalFlags)
 	})
 }
@@ -98,7 +98,7 @@ type PermsGroupsDeleteCmd struct {
 }
 
 func (p *PermsGroupsDeleteCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "permissions.groups.delete", []string{p.GroupID}, func() {
 		handlePolicyGroupDelete(ctx.Context, ctx.Client, []string{p.GroupID}, ctx.GlobalFlags)
 	})
 }
@@ -113,7 +113,7 @@ type PermsUsersListCmd struct {
 }
 
 func (p *PermsUsersListCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "permissions.users.list", []string{}, func() {
 		ctx.GlobalFlags.WithDetails = p.WithDetails
 		handleAccessControlUserList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
@@ -124,7 +124,7 @@ type PermsUsersGetCmd struct {
 }
 
 func (p *PermsUsersGetCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "permissions.users.get", []string{fmt.Sprintf("%d", p.UserID)}, func() {
 		handleAccessControlUserGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", p.UserID)}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_queries.go
+++ b/cmd/tdcli/command_queries.go
@@ -18,13 +18,11 @@ type QuerySubmitCmd struct {
 }
 
 func (q *QuerySubmitCmd) Run(ctx *CLIContext) error {
-	return InstrumentedRun(ctx, "queries.submit", []string{q.Query}, func(ctx *CLIContext) error {
-		return runHandlerWithErrorCapture(func() {
-			ctx.GlobalFlags.Database = q.Database
-			ctx.GlobalFlags.Priority = q.Priority
-			ctx.GlobalFlags.Engine = q.Engine
-			handleQuerySubmit(ctx.Context, ctx.Client, []string{q.Query}, ctx.GlobalFlags)
-		})
+	return runInstrumented(ctx, "queries.submit", []string{q.Query}, func() {
+		ctx.GlobalFlags.Database = q.Database
+		ctx.GlobalFlags.Priority = q.Priority
+		ctx.GlobalFlags.Engine = q.Engine
+		handleQuerySubmit(ctx.Context, ctx.Client, []string{q.Query}, ctx.GlobalFlags)
 	})
 }
 
@@ -33,10 +31,8 @@ type QueryStatusCmd struct {
 }
 
 func (q *QueryStatusCmd) Run(ctx *CLIContext) error {
-	return InstrumentedRun(ctx, "queries.status", []string{q.JobID}, func(ctx *CLIContext) error {
-		return runHandlerWithErrorCapture(func() {
-			handleQueryStatus(ctx.Context, ctx.Client, []string{q.JobID}, ctx.GlobalFlags)
-		})
+	return runInstrumented(ctx, "queries.status", []string{q.JobID}, func() {
+		handleQueryStatus(ctx.Context, ctx.Client, []string{q.JobID}, ctx.GlobalFlags)
 	})
 }
 
@@ -46,7 +42,7 @@ type QueryResultCmd struct {
 }
 
 func (q *QueryResultCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "queries.result", []string{q.JobID}, func() {
 		ctx.GlobalFlags.Limit = q.Limit
 		handleQueryResult(ctx.Context, ctx.Client, []string{q.JobID}, ctx.GlobalFlags)
 	})
@@ -57,7 +53,7 @@ type QueryListCmd struct {
 }
 
 func (q *QueryListCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "queries.list", []string{}, func() {
 		ctx.GlobalFlags.Status = q.Status
 		handleQueryList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
@@ -68,7 +64,7 @@ type QueryCancelCmd struct {
 }
 
 func (q *QueryCancelCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "queries.cancel", []string{q.JobID}, func() {
 		handleQueryCancel(ctx.Context, ctx.Client, []string{q.JobID}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_results.go
+++ b/cmd/tdcli/command_results.go
@@ -10,7 +10,7 @@ type ResultsGetCmd struct {
 }
 
 func (r *ResultsGetCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "results.get", []string{r.JobID}, func() {
 		ctx.GlobalFlags.Limit = r.Limit
 		handleResultGet(ctx.Context, ctx.Client, []string{r.JobID}, ctx.GlobalFlags)
 	})

--- a/cmd/tdcli/command_tables.go
+++ b/cmd/tdcli/command_tables.go
@@ -14,10 +14,8 @@ type TablesListCmd struct {
 }
 
 func (t *TablesListCmd) Run(ctx *CLIContext) error {
-	return InstrumentedRun(ctx, "tables.list", []string{t.Database}, func(ctx *CLIContext) error {
-		return runHandlerWithErrorCapture(func() {
-			handleTableList(ctx.Context, ctx.Client, []string{t.Database}, ctx.GlobalFlags)
-		})
+	return runInstrumented(ctx, "tables.list", []string{t.Database}, func() {
+		handleTableList(ctx.Context, ctx.Client, []string{t.Database}, ctx.GlobalFlags)
 	})
 }
 
@@ -27,7 +25,7 @@ type TablesGetCmd struct {
 }
 
 func (t *TablesGetCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "tables.get", []string{t.Database, t.Table}, func() {
 		handleTableGet(ctx.Context, ctx.Client, []string{t.Database, t.Table}, ctx.GlobalFlags)
 	})
 }
@@ -38,7 +36,7 @@ type TablesCreateCmd struct {
 }
 
 func (t *TablesCreateCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "tables.create", []string{t.Database, t.Table}, func() {
 		handleTableCreate(ctx.Context, ctx.Client, []string{t.Database, t.Table}, ctx.GlobalFlags)
 	})
 }
@@ -49,7 +47,7 @@ type TablesDeleteCmd struct {
 }
 
 func (t *TablesDeleteCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "tables.delete", []string{t.Database, t.Table}, func() {
 		handleTableDelete(ctx.Context, ctx.Client, []string{t.Database, t.Table}, ctx.GlobalFlags)
 	})
 }
@@ -61,7 +59,7 @@ type TablesSwapCmd struct {
 }
 
 func (t *TablesSwapCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "tables.swap", []string{t.Database, t.Table1, t.Table2}, func() {
 		handleTableSwap(ctx.Context, ctx.Client, []string{t.Database, t.Table1, t.Table2}, ctx.GlobalFlags)
 	})
 }
@@ -73,7 +71,7 @@ type TablesRenameCmd struct {
 }
 
 func (t *TablesRenameCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "tables.rename", []string{t.Database, t.OldName, t.NewName}, func() {
 		handleTableRename(ctx.Context, ctx.Client, []string{t.Database, t.OldName, t.NewName}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_trino.go
+++ b/cmd/tdcli/command_trino.go
@@ -20,12 +20,13 @@ type TrinoQueryCmd struct {
 func (t *TrinoQueryCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
 	ctx.GlobalFlags.Limit = t.Limit
-	if t.PageSize > 0 {
-		handleTrinoQueryWithPagination(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags, t.PageSize)
-	} else {
-		handleTrinoQuery(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags)
-	}
-	return nil
+	return runInstrumented(ctx, "trino.query", []string{t.Query}, func() {
+		if t.PageSize > 0 {
+			handleTrinoQueryWithPagination(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags, t.PageSize)
+		} else {
+			handleTrinoQuery(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags)
+		}
+	})
 }
 
 type TrinoInteractiveCmd struct {
@@ -34,8 +35,9 @@ type TrinoInteractiveCmd struct {
 
 func (t *TrinoInteractiveCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
-	handleTrinoInteractive(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "trino.interactive", []string{}, func() {
+		handleTrinoInteractive(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
+	})
 }
 
 type TrinoTestCmd struct {
@@ -44,8 +46,9 @@ type TrinoTestCmd struct {
 
 func (t *TrinoTestCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
-	handleTrinoTest(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "trino.test", []string{}, func() {
+		handleTrinoTest(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
+	})
 }
 
 type TrinoDescribeCmd struct {
@@ -55,8 +58,9 @@ type TrinoDescribeCmd struct {
 
 func (t *TrinoDescribeCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
-	handleTrinoDescribe(ctx.Context, ctx.Client, []string{t.Table}, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "trino.describe", []string{t.Table}, func() {
+		handleTrinoDescribe(ctx.Context, ctx.Client, []string{t.Table}, ctx.GlobalFlags)
+	})
 }
 
 type TrinoShowCmd struct {
@@ -71,8 +75,9 @@ func (t *TrinoShowCmd) Run(ctx *CLIContext) error {
 	if t.Table != "" {
 		args = append(args, t.Table)
 	}
-	handleTrinoShow(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "trino.show", args, func() {
+		handleTrinoShow(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	})
 }
 
 type TrinoExplainCmd struct {
@@ -82,8 +87,9 @@ type TrinoExplainCmd struct {
 
 func (t *TrinoExplainCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
-	handleTrinoExplain(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "trino.explain", []string{t.Query}, func() {
+		handleTrinoExplain(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags)
+	})
 }
 
 type TrinoVersionCmd struct {
@@ -92,6 +98,7 @@ type TrinoVersionCmd struct {
 
 func (t *TrinoVersionCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
-	handleTrinoVersion(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
-	return nil
+	return runInstrumented(ctx, "trino.version", []string{}, func() {
+		handleTrinoVersion(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
+	})
 }

--- a/cmd/tdcli/command_users.go
+++ b/cmd/tdcli/command_users.go
@@ -8,7 +8,7 @@ type UsersCmd struct {
 type UsersListCmd struct{}
 
 func (u *UsersListCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "users.list", []string{}, func() {
 		handleUserList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
@@ -18,7 +18,7 @@ type UsersGetCmd struct {
 }
 
 func (u *UsersGetCmd) Run(ctx *CLIContext) error {
-	return runHandlerWithErrorCapture(func() {
+	return runInstrumented(ctx, "users.get", []string{u.UserID}, func() {
 		handleUserGet(ctx.Context, ctx.Client, []string{u.UserID}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_workflow.go
+++ b/cmd/tdcli/command_workflow.go
@@ -166,8 +166,9 @@ type WorkflowScheduleGetCmd struct {
 
 func (w *WorkflowScheduleGetCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	workflow.HandleWorkflowScheduleGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
-	return nil
+	return runInstrumented(ctx, "workflow.schedule.get", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
+		workflow.HandleWorkflowScheduleGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
+	})
 }
 
 type WorkflowScheduleEnableCmd struct {
@@ -176,8 +177,9 @@ type WorkflowScheduleEnableCmd struct {
 
 func (w *WorkflowScheduleEnableCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	workflow.HandleWorkflowScheduleEnable(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
-	return nil
+	return runInstrumented(ctx, "workflow.schedule.enable", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
+		workflow.HandleWorkflowScheduleEnable(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
+	})
 }
 
 type WorkflowScheduleDisableCmd struct {
@@ -186,8 +188,9 @@ type WorkflowScheduleDisableCmd struct {
 
 func (w *WorkflowScheduleDisableCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	workflow.HandleWorkflowScheduleDisable(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
-	return nil
+	return runInstrumented(ctx, "workflow.schedule.disable", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
+		workflow.HandleWorkflowScheduleDisable(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
+	})
 }
 
 type WorkflowScheduleUpdateCmd struct {
@@ -199,10 +202,11 @@ type WorkflowScheduleUpdateCmd struct {
 
 func (w *WorkflowScheduleUpdateCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	workflow.HandleWorkflowScheduleUpdate(ctx.Context, ctx.Client, []string{
-		fmt.Sprintf("%d", w.WorkflowID), w.Cron, w.Timezone, fmt.Sprintf("%d", w.Delay),
-	}, flags)
-	return nil
+	return runInstrumented(ctx, "workflow.schedule.update", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
+		workflow.HandleWorkflowScheduleUpdate(ctx.Context, ctx.Client, []string{
+			fmt.Sprintf("%d", w.WorkflowID), w.Cron, w.Timezone, fmt.Sprintf("%d", w.Delay),
+		}, flags)
+	})
 }
 
 type WorkflowTasksCmd struct {
@@ -217,8 +221,9 @@ type WorkflowTasksListCmd struct {
 
 func (w *WorkflowTasksListCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	workflow.HandleWorkflowTaskList(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
-	return nil
+	return runInstrumented(ctx, "workflow.tasks.list", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() {
+		workflow.HandleWorkflowTaskList(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
+	})
 }
 
 type WorkflowTasksGetCmd struct {
@@ -229,8 +234,9 @@ type WorkflowTasksGetCmd struct {
 
 func (w *WorkflowTasksGetCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	workflow.HandleWorkflowTaskGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, flags)
-	return nil
+	return runInstrumented(ctx, "workflow.tasks.get", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, func() {
+		workflow.HandleWorkflowTaskGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, flags)
+	})
 }
 
 type WorkflowLogsCmd struct {
@@ -245,8 +251,9 @@ type WorkflowLogsAttemptCmd struct {
 
 func (w *WorkflowLogsAttemptCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	workflow.HandleWorkflowAttemptLog(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
-	return nil
+	return runInstrumented(ctx, "workflow.logs.attempt", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() {
+		workflow.HandleWorkflowAttemptLog(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
+	})
 }
 
 type WorkflowLogsTaskCmd struct {
@@ -257,8 +264,9 @@ type WorkflowLogsTaskCmd struct {
 
 func (w *WorkflowLogsTaskCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	workflow.HandleWorkflowTaskLog(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, flags)
-	return nil
+	return runInstrumented(ctx, "workflow.logs.task", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, func() {
+		workflow.HandleWorkflowTaskLog(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, flags)
+	})
 }
 
 type WorkflowInitCmd struct {
@@ -267,8 +275,9 @@ type WorkflowInitCmd struct {
 
 func (w *WorkflowInitCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	workflow.HandleWorkflowInit(ctx.Context, []string{w.ProjectName}, flags)
-	return nil
+	return runInstrumented(ctx, "workflow.init", []string{w.ProjectName}, func() {
+		workflow.HandleWorkflowInit(ctx.Context, []string{w.ProjectName}, flags)
+	})
 }
 
 type WorkflowProjectsCmd struct {

--- a/cmd/tdcli/trino.go
+++ b/cmd/tdcli/trino.go
@@ -971,6 +971,9 @@ func trinoClientError(operation string, err error, flags Flags) {
 	fmt.Printf("  Region: %s\n", flags.Region)
 	fmt.Printf("  Database: %s\n", flags.Database)
 
+	if captureHandlerErrors {
+		panic(fmt.Errorf("failed to %s: %v", operation, err))
+	}
 	log.Fatal("")
 }
 
@@ -1026,6 +1029,9 @@ func enhanceTrinoQueryError(operation string, err error, query string, flags Fla
 		fmt.Printf("  • Use --verbose flag for more detailed error information\n")
 	}
 
+	if captureHandlerErrors {
+		panic(fmt.Errorf("failed to %s: %v", operation, err))
+	}
 	log.Fatal("")
 }
 

--- a/cmd/tdcli/workflow/types.go
+++ b/cmd/tdcli/workflow/types.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 
@@ -55,7 +56,19 @@ func PrintJSON(v interface{}) {
 	}
 }
 
+// CaptureErrors signals HandleError to panic instead of calling log.Fatalf.
+// Set by the main package's runHandlerWithErrorCapture when wrapping commands.
+var CaptureErrors = false
+
 func HandleError(err error, message string, verbose bool) {
+	if err != nil {
+		if CaptureErrors {
+			if verbose {
+				panic(fmt.Errorf("%s: %v", message, err))
+			}
+			panic(err)
+		}
+	}
 	if verbose {
 		if tdErr, ok := err.(*td.ErrorResponse); ok {
 			log.Printf("API Error: %s\n", tdErr.Error())


### PR DESCRIPTION
## Summary

- Replaces all inconsistent instrumentation patterns with a single `runInstrumented()` call per `Run()` method
- 70 previously inconsistent subcommands now use uniform OTEL spans/metrics + error capture

## Details

Three patterns were consolidated into `runInstrumented()`:

| Pattern | Before | After |
|---------|--------|-------|
| `runHandlerWithErrorCapture` only (no OTEL) | 40 | 0 |
| Direct call + `return nil` (no OTEL, no error capture) | 24 | 0 |
| Inline `InstrumentedRun` + `runHandlerWithErrorCapture` (verbose) | 6 | 0 |
| `runInstrumented` (consistent) | 95 | 165 |

Key behavioral fix: commands that previously returned `nil` regardless of errors (Trino, workflow schedule/tasks/logs/init, CDP journey subcommands) now properly surface errors to Kong's runner.

Closes #67