### PR TITLE
fix: refactor CLI handlers to return errors instead of os.Exit/panic

### DIFF
--- a/cmd/tdcli/bulk-import.go
+++ b/cmd/tdcli/bulk-import.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -9,81 +10,11 @@ import (
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-func handleBulkImportCommands(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	if len(args) == 0 || args[0] == "help" {
-		printBulkImportUsage()
-		return
-	}
-
-	subcommand := args[0]
-	subArgs := args[1:]
-
-	switch subcommand {
-	case "list", "ls":
-		handleBulkImportList(ctx, client, flags)
-	case "get", "show":
-		handleBulkImportGet(ctx, client, subArgs, flags)
-	case "create":
-		handleBulkImportCreate(ctx, client, subArgs, flags)
-	case "delete", "rm":
-		handleBulkImportDelete(ctx, client, subArgs, flags)
-	case "upload":
-		handleBulkImportUpload(ctx, client, subArgs, flags)
-	case "commit":
-		handleBulkImportCommit(ctx, client, subArgs, flags)
-	case "perform":
-		handleBulkImportPerform(ctx, client, subArgs, flags)
-	case "freeze":
-		handleBulkImportFreeze(ctx, client, subArgs, flags)
-	case "unfreeze":
-		handleBulkImportUnfreeze(ctx, client, subArgs, flags)
-	case "parts":
-		handleBulkImportParts(ctx, client, subArgs, flags)
-	default:
-		fmt.Printf("Unknown bulk import subcommand: %s\n", subcommand)
-		printBulkImportUsage()
-		os.Exit(1)
-	}
-}
-
-func printBulkImportUsage() {
-	fmt.Printf(`Bulk Import Management Commands
-
-USAGE:
-    tdcli bulk-import <subcommand> [options]
-    tdcli import <subcommand> [options]
-
-SUBCOMMANDS:
-    list, ls               List bulk import sessions
-    get, show <session>    Get bulk import session details
-    create <session> <database> <table>  Create a new bulk import session
-    delete, rm <session>   Delete a bulk import session
-    upload <session> <part> <file>  Upload a part to session
-    commit <session>       Commit a bulk import session
-    perform <session>      Perform bulk import job
-    freeze <session>       Freeze a bulk import session
-    unfreeze <session>     Unfreeze a bulk import session
-    parts <session>        List parts in a bulk import session
-
-OPTIONS:
-    --format FORMAT        Output format (json, table, csv)
-    --verbose, -v          Verbose output
-
-EXAMPLES:
-    tdcli import list
-    tdcli import show my_session
-    tdcli import create my_session my_db my_table
-    tdcli import upload my_session part1 data.csv
-    tdcli import commit my_session
-    tdcli import perform my_session
-    tdcli import parts my_session
-
-`)
-}
-
-func handleBulkImportList(ctx context.Context, client *td.Client, flags Flags) {
+func handleBulkImportList(ctx context.Context, client *td.Client, flags Flags) error {
 	bulkImports, err := client.BulkImport.List(ctx)
-	handleError(err, "Failed to list bulk import sessions", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to list bulk import sessions", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -93,18 +24,19 @@ func handleBulkImportList(ctx context.Context, client *td.Client, flags Flags) {
 	default:
 		printBulkImportsTable(bulkImports)
 	}
+	return nil
 }
 
-func handleBulkImportGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleBulkImportGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Session name required")
-		fmt.Println("Usage: tdcli import get <session_name>")
-		os.Exit(1)
+		return errors.New("session name required\nUsage: tdcli import get <session_name>")
 	}
 
 	sessionName := args[0]
 	bulkImport, err := client.BulkImport.Show(ctx, sessionName)
-	handleError(err, "Failed to get bulk import session", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to get bulk import session", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -114,74 +46,70 @@ func handleBulkImportGet(ctx context.Context, client *td.Client, args []string, 
 	default:
 		printBulkImportDetails(*bulkImport)
 	}
+	return nil
 }
 
-func handleBulkImportCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleBulkImportCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		fmt.Println("Error: Session name, database, and table required")
-		fmt.Println("Usage: tdcli import create <session_name> <database> <table>")
-		os.Exit(1)
+		return errors.New("session name, database, and table required\nUsage: tdcli import create <session_name> <database> <table>")
 	}
 
 	sessionName := args[0]
 	database := args[1]
 	table := args[2]
 
-	err := client.BulkImport.Create(ctx, sessionName, database, table)
-	handleError(err, "Failed to create bulk import session", flags.Verbose)
+	if err := client.BulkImport.Create(ctx, sessionName, database, table); err != nil {
+		return wrapErr(err, "failed to create bulk import session", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully created bulk import session: %s for %s.%s\n", sessionName, database, table)
 	} else {
 		fmt.Printf("Created bulk import session: %s\n", sessionName)
 	}
+	return nil
 }
 
-func handleBulkImportDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleBulkImportDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Session name required")
-		fmt.Println("Usage: tdcli import delete <session_name>")
-		os.Exit(1)
+		return errors.New("session name required\nUsage: tdcli import delete <session_name>")
 	}
 
 	sessionName := args[0]
 
-	// Confirm deletion
 	fmt.Printf("Are you sure you want to delete bulk import session '%s'? (y/N): ", sessionName)
 	var response string
 	fmt.Scanln(&response)
 
 	if response != "y" && response != "Y" && response != "yes" && response != "Yes" {
 		fmt.Println("Deletion cancelled")
-		return
+		return nil
 	}
 
-	err := client.BulkImport.Delete(ctx, sessionName)
-	handleError(err, "Failed to delete bulk import session", flags.Verbose)
+	if err := client.BulkImport.Delete(ctx, sessionName); err != nil {
+		return wrapErr(err, "failed to delete bulk import session", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully deleted bulk import session: %s\n", sessionName)
 	} else {
 		fmt.Printf("Deleted bulk import session: %s\n", sessionName)
 	}
+	return nil
 }
 
-func handleBulkImportUpload(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleBulkImportUpload(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		fmt.Println("Error: Session name, part name, and file path required")
-		fmt.Println("Usage: tdcli import upload <session_name> <part_name> <file_path>")
-		os.Exit(1)
+		return errors.New("session name, part name, and file path required\nUsage: tdcli import upload <session_name> <part_name> <file_path>")
 	}
 
 	sessionName := args[0]
 	partName := args[1]
 	filePath := args[2]
 
-	// Open file
 	file, err := os.Open(filePath)
 	if err != nil {
-		handleError(err, "Failed to open file", flags.Verbose)
-		return
+		return wrapErr(err, "failed to open file", flags.Verbose)
 	}
 	defer file.Close()
 
@@ -189,50 +117,49 @@ func handleBulkImportUpload(ctx context.Context, client *td.Client, args []strin
 		fmt.Printf("Uploading file %s as part %s to session %s...\n", filePath, partName, sessionName)
 	}
 
-	err = client.BulkImport.UploadPart(ctx, sessionName, partName, file)
-	handleError(err, "Failed to upload part", flags.Verbose)
+	if err := client.BulkImport.UploadPart(ctx, sessionName, partName, file); err != nil {
+		return wrapErr(err, "failed to upload part", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully uploaded part %s to session %s\n", partName, sessionName)
 	} else {
 		fmt.Printf("Uploaded part: %s\n", partName)
 	}
+	return nil
 }
 
-func handleBulkImportCommit(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleBulkImportCommit(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Session name required")
-		fmt.Println("Usage: tdcli import commit <session_name>")
-		os.Exit(1)
+		return errors.New("session name required\nUsage: tdcli import commit <session_name>")
 	}
 
 	sessionName := args[0]
 
-	// Confirm commit
 	fmt.Printf("Are you sure you want to commit bulk import session '%s'? (y/N): ", sessionName)
 	var response string
 	fmt.Scanln(&response)
 
 	if response != "y" && response != "Y" && response != "yes" && response != "Yes" {
 		fmt.Println("Commit cancelled")
-		return
+		return nil
 	}
 
-	err := client.BulkImport.Commit(ctx, sessionName)
-	handleError(err, "Failed to commit bulk import session", flags.Verbose)
+	if err := client.BulkImport.Commit(ctx, sessionName); err != nil {
+		return wrapErr(err, "failed to commit bulk import session", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully committed bulk import session: %s\n", sessionName)
 	} else {
 		fmt.Printf("Committed bulk import session: %s\n", sessionName)
 	}
+	return nil
 }
 
-func handleBulkImportPerform(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleBulkImportPerform(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Session name required")
-		fmt.Println("Usage: tdcli import perform <session_name>")
-		os.Exit(1)
+		return errors.New("session name required\nUsage: tdcli import perform <session_name>")
 	}
 
 	sessionName := args[0]
@@ -242,7 +169,9 @@ func handleBulkImportPerform(ctx context.Context, client *td.Client, args []stri
 	}
 
 	job, err := client.BulkImport.Perform(ctx, sessionName)
-	handleError(err, "Failed to perform bulk import", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to perform bulk import", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully started bulk import job for session: %s\n", sessionName)
@@ -250,56 +179,57 @@ func handleBulkImportPerform(ctx context.Context, client *td.Client, args []stri
 	} else {
 		fmt.Printf("Started bulk import job: %s\n", job.JobID)
 	}
+	return nil
 }
 
-func handleBulkImportFreeze(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleBulkImportFreeze(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Session name required")
-		fmt.Println("Usage: tdcli import freeze <session_name>")
-		os.Exit(1)
+		return errors.New("session name required\nUsage: tdcli import freeze <session_name>")
 	}
 
 	sessionName := args[0]
 
-	err := client.BulkImport.Freeze(ctx, sessionName)
-	handleError(err, "Failed to freeze bulk import session", flags.Verbose)
+	if err := client.BulkImport.Freeze(ctx, sessionName); err != nil {
+		return wrapErr(err, "failed to freeze bulk import session", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully froze bulk import session: %s\n", sessionName)
 	} else {
 		fmt.Printf("Froze bulk import session: %s\n", sessionName)
 	}
+	return nil
 }
 
-func handleBulkImportUnfreeze(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleBulkImportUnfreeze(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Session name required")
-		fmt.Println("Usage: tdcli import unfreeze <session_name>")
-		os.Exit(1)
+		return errors.New("session name required\nUsage: tdcli import unfreeze <session_name>")
 	}
 
 	sessionName := args[0]
 
-	err := client.BulkImport.Unfreeze(ctx, sessionName)
-	handleError(err, "Failed to unfreeze bulk import session", flags.Verbose)
+	if err := client.BulkImport.Unfreeze(ctx, sessionName); err != nil {
+		return wrapErr(err, "failed to unfreeze bulk import session", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully unfroze bulk import session: %s\n", sessionName)
 	} else {
 		fmt.Printf("Unfroze bulk import session: %s\n", sessionName)
 	}
+	return nil
 }
 
-func handleBulkImportParts(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleBulkImportParts(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Session name required")
-		fmt.Println("Usage: tdcli import parts <session_name>")
-		os.Exit(1)
+		return errors.New("session name required\nUsage: tdcli import parts <session_name>")
 	}
 
 	sessionName := args[0]
 	parts, err := client.BulkImport.ListParts(ctx, sessionName)
-	handleError(err, "Failed to list bulk import parts", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to list bulk import parts", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -309,9 +239,9 @@ func handleBulkImportParts(ctx context.Context, client *td.Client, args []string
 	default:
 		printBulkImportPartsTable(parts, sessionName)
 	}
+	return nil
 }
 
-// Print functions
 func printBulkImportsTable(bulkImports []td.BulkImport) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "NAME\tDATABASE\tTABLE\tSTATUS\tVALID_RECORDS\tERROR_RECORDS\tCREATED")

--- a/cmd/tdcli/cdp.go
+++ b/cmd/tdcli/cdp.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"errors"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 	cdphandlers "github.com/mickeey2525/treasuredata-go-sdk/cmd/tdcli/cdp"
@@ -30,330 +30,330 @@ func buildCDPFlags(flags Flags) cdphandlers.Flags {
 }
 
 // CDP segment handlers
-func handleCDPSegmentCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentCreate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentCreate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPSegmentList(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentList(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentList(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPSegmentGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentGet(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentGet(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPSegmentUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentUpdate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentUpdate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPSegmentDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentDelete(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentDelete(ctx, client, args, buildCDPFlags(flags))
 }
 
 // CDP audience handlers
-func handleCDPAudienceCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleAudienceCreate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPAudienceCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleAudienceCreate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPAudienceList(ctx context.Context, client *td.Client, flags Flags) {
-	cdphandlers.HandleAudienceList(ctx, client, buildCDPFlags(flags))
+func handleCDPAudienceList(ctx context.Context, client *td.Client, flags Flags) error {
+	return cdphandlers.HandleAudienceList(ctx, client, buildCDPFlags(flags))
 }
 
-func handleCDPAudienceGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleAudienceGet(ctx, client, args, buildCDPFlags(flags))
+func handleCDPAudienceGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleAudienceGet(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPAudienceDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleAudienceDelete(ctx, client, args, buildCDPFlags(flags))
+func handleCDPAudienceDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleAudienceDelete(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPAudienceUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleAudienceUpdate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPAudienceUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleAudienceUpdate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPAudienceAttributes(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleAudienceAttributes(ctx, client, args, buildCDPFlags(flags))
+func handleCDPAudienceAttributes(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleAudienceAttributes(ctx, client, args, buildCDPFlags(flags))
 }
 
 // CDP audience behavior handlers
-func handleCDPAudienceBehaviors(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleAudienceBehaviors(ctx, client, args, buildCDPFlags(flags))
+func handleCDPAudienceBehaviors(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleAudienceBehaviors(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPAudienceRun(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleAudienceRun(ctx, client, args, buildCDPFlags(flags))
+func handleCDPAudienceRun(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleAudienceRun(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPAudienceExecutions(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleAudienceExecutions(ctx, client, args, buildCDPFlags(flags))
+func handleCDPAudienceExecutions(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleAudienceExecutions(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPAudienceStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleAudienceStatistics(ctx, client, args, buildCDPFlags(flags))
+func handleCDPAudienceStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleAudienceStatistics(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPAudienceSampleValues(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleAudienceSampleValues(ctx, client, args, buildCDPFlags(flags))
+func handleCDPAudienceSampleValues(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleAudienceSampleValues(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPAudienceBehaviorSamples(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleAudienceBehaviorSamples(ctx, client, args, buildCDPFlags(flags))
+func handleCDPAudienceBehaviorSamples(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleAudienceBehaviorSamples(ctx, client, args, buildCDPFlags(flags))
 }
 
 // CDP segment folder handlers
-func handleCDPSegmentFolders(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentFolders(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentFolders(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentFolders(ctx, client, args, buildCDPFlags(flags))
 }
 
 // Additional segment handlers for query operations
-func handleCDPSegmentQuery(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentQuery(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentQuery(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentQuery(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPSegmentNewQuery(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentNewQuery(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentNewQuery(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentNewQuery(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPSegmentQueryStatus(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentQueryStatus(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentQueryStatus(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentQueryStatus(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPSegmentKillQuery(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentKillQuery(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentKillQuery(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentKillQuery(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPSegmentCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentCustomers(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentCustomers(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPSegmentStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleSegmentStatistics(ctx, client, args, buildCDPFlags(flags))
+func handleCDPSegmentStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleSegmentStatistics(ctx, client, args, buildCDPFlags(flags))
 }
 
 // CDP activation handlers
-func handleCDPActivationCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationCreate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPActivationCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationCreate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPActivationCreateWithStruct(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationCreateWithStruct(ctx, client, args, buildCDPFlags(flags))
+func handleCDPActivationCreateWithStruct(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationCreateWithStruct(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPActivationListWithForce(ctx context.Context, client *td.Client, flags Flags, force bool) {
-	cdphandlers.HandleActivationListWithForce(ctx, client, buildCDPFlags(flags), force)
+func handleCDPActivationListWithForce(ctx context.Context, client *td.Client, flags Flags, force bool) error {
+	return cdphandlers.HandleActivationListWithForce(ctx, client, buildCDPFlags(flags), force)
 }
 
-func handleCDPActivationGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationGet(ctx, client, args, buildCDPFlags(flags))
+func handleCDPActivationGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationGet(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPActivationUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationUpdate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPActivationUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationUpdate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPActivationUpdateStatus(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationUpdateStatus(ctx, client, args, buildCDPFlags(flags))
+func handleCDPActivationUpdateStatus(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationUpdateStatus(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPActivationDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationDelete(ctx, client, args, buildCDPFlags(flags))
+func handleCDPActivationDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationDelete(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPExecuteActivation(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationExecute(ctx, client, args, buildCDPFlags(flags))
+func handleCDPExecuteActivation(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationExecute(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPGetActivationExecutions(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationGetExecutions(ctx, client, args, buildCDPFlags(flags))
+func handleCDPGetActivationExecutions(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationGetExecutions(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPListActivationsByAudience(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationListByAudience(ctx, client, args, buildCDPFlags(flags))
+func handleCDPListActivationsByAudience(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationListByAudience(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPListActivationsBySegmentFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationListBySegmentFolder(ctx, client, args, buildCDPFlags(flags))
+func handleCDPListActivationsBySegmentFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationListBySegmentFolder(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPRunSegmentActivation(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationRunForSegment(ctx, client, args, buildCDPFlags(flags))
+func handleCDPRunSegmentActivation(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationRunForSegment(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPListActivationsByParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationListByParentSegment(ctx, client, args, buildCDPFlags(flags))
+func handleCDPListActivationsByParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationListByParentSegment(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPGetWorkflowProjectsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleGetWorkflowProjectsForParentSegment(ctx, client, args, buildCDPFlags(flags))
+func handleCDPGetWorkflowProjectsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleGetWorkflowProjectsForParentSegment(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPGetWorkflowsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleGetWorkflowsForParentSegment(ctx, client, args, buildCDPFlags(flags))
+func handleCDPGetWorkflowsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleGetWorkflowsForParentSegment(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPGetMatchedActivations(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	log.Fatal("Get matched activations is not yet implemented")
+func handleCDPGetMatchedActivations(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return errors.New("get matched activations is not yet implemented")
 }
 
-func handleCDPRunActivationForSegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	log.Fatal("Run activation for segment is not yet implemented")
+func handleCDPRunActivationForSegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return errors.New("run activation for segment is not yet implemented")
 }
 
-func handleCDPGetMatchedActivationsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleGetMatchedActivationsForParentSegment(ctx, client, args, buildCDPFlags(flags))
+func handleCDPGetMatchedActivationsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleGetMatchedActivationsForParentSegment(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPListFolders(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleListFolders(ctx, client, args, buildCDPFlags(flags))
+func handleCDPListFolders(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleListFolders(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPCreateAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleCreateAudienceFolder(ctx, client, args, buildCDPFlags(flags))
+func handleCDPCreateAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleCreateAudienceFolder(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPGetAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleGetAudienceFolder(ctx, client, args, buildCDPFlags(flags))
+func handleCDPGetAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleGetAudienceFolder(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPCreateEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleCreateEntityFolder(ctx, client, args, buildCDPFlags(flags))
+func handleCDPCreateEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleCreateEntityFolder(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPGetEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleGetEntityFolder(ctx, client, args, buildCDPFlags(flags))
+func handleCDPGetEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleGetEntityFolder(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPUpdateEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleUpdateEntityFolder(ctx, client, args, buildCDPFlags(flags))
+func handleCDPUpdateEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleUpdateEntityFolder(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPDeleteEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleDeleteEntityFolder(ctx, client, args, buildCDPFlags(flags))
+func handleCDPDeleteEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleDeleteEntityFolder(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPGetEntitiesByFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleGetEntitiesByFolder(ctx, client, args, buildCDPFlags(flags))
+func handleCDPGetEntitiesByFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleGetEntitiesByFolder(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPListTokens(ctx context.Context, client *td.Client, cmd interface{}, flags Flags) {
-	cdphandlers.HandleListTokens(ctx, client, cmd, buildCDPFlags(flags))
+func handleCDPListTokens(ctx context.Context, client *td.Client, cmd interface{}, flags Flags) error {
+	return cdphandlers.HandleListTokens(ctx, client, cmd, buildCDPFlags(flags))
 }
 
-func handleCDPGetEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleGetEntityToken(ctx, client, args, buildCDPFlags(flags))
+func handleCDPGetEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleGetEntityToken(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPUpdateEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleUpdateEntityToken(ctx, client, args, buildCDPFlags(flags))
+func handleCDPUpdateEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleUpdateEntityToken(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPDeleteEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleDeleteEntityToken(ctx, client, args, buildCDPFlags(flags))
+func handleCDPDeleteEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleDeleteEntityToken(ctx, client, args, buildCDPFlags(flags))
 }
 
 // Journey handlers
-func handleCDPJourneyList(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyList(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyList(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyCreate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyCreate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyGet(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyGet(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyUpdate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyUpdate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyDelete(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyDelete(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyDetail(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyDetail(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyDetail(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyDetail(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyDuplicate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyDuplicate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyDuplicate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyDuplicate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyPause(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyPause(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyPause(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyPause(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyResume(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyResume(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyResume(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyResume(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyStatistics(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyStatistics(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyCustomers(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyCustomers(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyStageCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyStageCustomers(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyStageCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyStageCustomers(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyConversionSankey(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyConversionSankey(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyConversionSankey(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyConversionSankey(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyActivationSankey(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyActivationSankey(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyActivationSankey(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyActivationSankey(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneySegmentRules(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneySegmentRules(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneySegmentRules(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneySegmentRules(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyBehaviors(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyBehaviors(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyBehaviors(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyBehaviors(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyTemplates(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyTemplates(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyTemplates(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyTemplates(ctx, client, args, buildCDPFlags(flags))
 }
 
 // Journey Activation handlers
-func handleCDPJourneyActivationList(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyActivationList(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyActivationList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyActivationList(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyActivationCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyActivationCreate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyActivationCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyActivationCreate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyActivationGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyActivationGet(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyActivationGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyActivationGet(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPJourneyActivationUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleJourneyActivationUpdate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPJourneyActivationUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleJourneyActivationUpdate(ctx, client, args, buildCDPFlags(flags))
 }
 
 // Activation Template handlers
-func handleCDPActivationTemplateList(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationTemplateList(ctx, client, args, buildCDPFlags(flags))
+func handleCDPActivationTemplateList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationTemplateList(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPActivationTemplateCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationTemplateCreate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPActivationTemplateCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationTemplateCreate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPActivationTemplateGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationTemplateGet(ctx, client, args, buildCDPFlags(flags))
+func handleCDPActivationTemplateGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationTemplateGet(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPActivationTemplateUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationTemplateUpdate(ctx, client, args, buildCDPFlags(flags))
+func handleCDPActivationTemplateUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationTemplateUpdate(ctx, client, args, buildCDPFlags(flags))
 }
 
-func handleCDPActivationTemplateDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	cdphandlers.HandleActivationTemplateDelete(ctx, client, args, buildCDPFlags(flags))
+func handleCDPActivationTemplateDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return cdphandlers.HandleActivationTemplateDelete(ctx, client, args, buildCDPFlags(flags))
 }

--- a/cmd/tdcli/cdp/activation_templates.go
+++ b/cmd/tdcli/cdp/activation_templates.go
@@ -10,111 +10,91 @@ import (
 )
 
 // HandleActivationTemplateList handles listing activation templates by parent segment
-func HandleActivationTemplateList(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationTemplateList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Parent Segment ID is required", flags.Verbose)
+		return usageError("Parent Segment ID is required")
 	}
 
-	parentSegmentID := args[0]
-
-	templates, err := client.CDP.ListActivationTemplatesByParentSegment(ctx, parentSegmentID)
+	templates, err := client.CDP.ListActivationTemplatesByParentSegment(ctx, args[0])
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to list activation templates", flags.Verbose)
 	}
 
-	FormatOutput(templates, flags.Format, flags.Output)
+	return FormatOutput(templates, flags.Format, flags.Output)
 }
 
 // HandleActivationTemplateCreate handles activation template creation
-func HandleActivationTemplateCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationTemplateCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Request file is required", flags.Verbose)
+		return usageError("Request file is required")
 	}
 
-	requestFile := args[0]
-
-	// Read the request file
-	requestData, err := os.ReadFile(requestFile)
+	requestData, err := os.ReadFile(args[0])
 	if err != nil {
-		handleUsageError(fmt.Sprintf("Error reading request file: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error reading request file: %v", err))
 	}
 
-	// Parse the request
 	var request td.CDPActivationTemplateRequest
 	if err := json.Unmarshal(requestData, &request); err != nil {
-		handleUsageError(fmt.Sprintf("Error parsing request JSON: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error parsing request JSON: %v", err))
 	}
 
 	template, err := client.CDP.CreateActivationTemplate(ctx, &request)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to create activation template", flags.Verbose)
 	}
 
-	FormatOutput(template, flags.Format, flags.Output)
+	return FormatOutput(template, flags.Format, flags.Output)
 }
 
 // HandleActivationTemplateGet handles getting activation template details
-func HandleActivationTemplateGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationTemplateGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Template ID is required", flags.Verbose)
+		return usageError("Template ID is required")
 	}
 
-	templateID := args[0]
-
-	template, err := client.CDP.GetActivationTemplate(ctx, templateID)
+	template, err := client.CDP.GetActivationTemplate(ctx, args[0])
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to get activation template", flags.Verbose)
 	}
 
-	FormatOutput(template, flags.Format, flags.Output)
+	return FormatOutput(template, flags.Format, flags.Output)
 }
 
 // HandleActivationTemplateUpdate handles activation template updates
-func HandleActivationTemplateUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationTemplateUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Error: Template ID and request file are required", flags.Verbose)
+		return usageError("Template ID and request file are required")
 	}
 
-	templateID := args[0]
-	requestFile := args[1]
-
-	// Read the request file
-	requestData, err := os.ReadFile(requestFile)
+	requestData, err := os.ReadFile(args[1])
 	if err != nil {
-		handleUsageError(fmt.Sprintf("Error reading request file: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error reading request file: %v", err))
 	}
 
-	// Parse the request
 	var request td.CDPActivationTemplateRequest
 	if err := json.Unmarshal(requestData, &request); err != nil {
-		handleUsageError(fmt.Sprintf("Error parsing request JSON: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error parsing request JSON: %v", err))
 	}
 
-	template, err := client.CDP.UpdateActivationTemplate(ctx, templateID, &request)
+	template, err := client.CDP.UpdateActivationTemplate(ctx, args[0], &request)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to update activation template", flags.Verbose)
 	}
 
-	FormatOutput(template, flags.Format, flags.Output)
+	return FormatOutput(template, flags.Format, flags.Output)
 }
 
 // HandleActivationTemplateDelete handles activation template deletion
-func HandleActivationTemplateDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationTemplateDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Template ID is required", flags.Verbose)
+		return usageError("Template ID is required")
 	}
 
-	templateID := args[0]
-
-	err := client.CDP.DeleteActivationTemplate(ctx, templateID)
-	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+	if err := client.CDP.DeleteActivationTemplate(ctx, args[0]); err != nil {
+		return wrapError(err, "failed to delete activation template", flags.Verbose)
 	}
 
-	fmt.Printf("Activation template %s deleted successfully\n", templateID)
+	fmt.Printf("Activation template %s deleted successfully\n", args[0])
+	return nil
 }

--- a/cmd/tdcli/cdp/activations.go
+++ b/cmd/tdcli/cdp/activations.go
@@ -3,6 +3,7 @@ package cdp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -12,41 +13,40 @@ import (
 )
 
 // HandleActivationCreate creates a new CDP activation
-func HandleActivationCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 4 {
-		handleUsageError("Segment ID, name, description, and configuration (JSON) required", flags.Verbose)
+		return usageError("Segment ID, name, description, and configuration (JSON) required")
 	}
 
 	var config map[string]interface{}
 	if args[3] != "" {
-		err := json.Unmarshal([]byte(args[3]), &config)
-		if err != nil {
-			handleUsageError(fmt.Sprintf("Invalid configuration JSON: %v", err), flags.Verbose)
+		if err := json.Unmarshal([]byte(args[3]), &config); err != nil {
+			return usageError(fmt.Sprintf("Invalid configuration JSON: %v", err))
 		}
 	}
 
 	activation, err := client.CDP.CreateActivation(ctx, args[0], args[1], args[2], config)
 	if err != nil {
-		handleError(err, "Failed to create activation", flags.Verbose)
+		return wrapError(err, "failed to create activation", flags.Verbose)
 	}
 
 	fmt.Printf("Activation created successfully\n")
 	fmt.Printf("ID: %s\n", activation.ID)
 	fmt.Printf("Name: %s\n", activation.Name)
 	fmt.Printf("Status: %s\n", activation.Status)
+	return nil
 }
 
 // HandleActivationCreateWithStruct creates a new CDP activation using struct-based API
-func HandleActivationCreateWithStruct(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationCreateWithStruct(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 4 {
-		handleUsageError("Name, type, segment ID, and configuration (JSON) required", flags.Verbose)
+		return usageError("Name, type, segment ID, and configuration (JSON) required")
 	}
 
 	var config map[string]interface{}
 	if args[3] != "" {
-		err := json.Unmarshal([]byte(args[3]), &config)
-		if err != nil {
-			handleUsageError(fmt.Sprintf("Invalid configuration JSON: %v", err), flags.Verbose)
+		if err := json.Unmarshal([]byte(args[3]), &config); err != nil {
+			return usageError(fmt.Sprintf("Invalid configuration JSON: %v", err))
 		}
 	}
 
@@ -62,17 +62,18 @@ func HandleActivationCreateWithStruct(ctx context.Context, client *td.Client, ar
 
 	activation, err := client.CDP.CreateActivationWithRequest(ctx, args[2], req)
 	if err != nil {
-		handleError(err, "Failed to create activation with struct", flags.Verbose)
+		return wrapError(err, "failed to create activation with struct", flags.Verbose)
 	}
 
 	fmt.Printf("Activation created successfully\n")
 	fmt.Printf("ID: %s\n", activation.ID)
 	fmt.Printf("Name: %s\n", activation.Name)
 	fmt.Printf("Status: %s\n", activation.Status)
+	return nil
 }
 
 // HandleActivationListWithForce lists all activations with optional force flag
-func HandleActivationListWithForce(ctx context.Context, client *td.Client, flags Flags, force bool) {
+func HandleActivationListWithForce(ctx context.Context, client *td.Client, flags Flags, force bool) error {
 	fmt.Println("⚠️  Warning: 'cdp activations ls' lists activations from ALL audiences.")
 	fmt.Println("    For better performance, use specific commands:")
 	fmt.Println("    • cdp activations list-by-audience <audience-id>        - List activations for specific audience")
@@ -81,15 +82,14 @@ func HandleActivationListWithForce(ctx context.Context, client *td.Client, flags
 	fmt.Println("    • cdp audience ls                                      - List available audiences first")
 	fmt.Println()
 
-	// First get a list of audiences to show activations from all audiences
 	audiences, err := client.CDP.ListAudiences(ctx)
 	if err != nil {
-		handleError(err, "Failed to list audiences", flags.Verbose)
+		return wrapError(err, "failed to list audiences", flags.Verbose)
 	}
 
 	if len(audiences.Audiences) == 0 {
 		fmt.Println("No audiences found")
-		return
+		return nil
 	}
 
 	fmt.Printf("Found %d audiences. This will make %d API calls to collect all activations.\n", len(audiences.Audiences), len(audiences.Audiences))
@@ -103,7 +103,7 @@ func HandleActivationListWithForce(ctx context.Context, client *td.Client, flags
 
 		if response != "y" && response != "yes" {
 			fmt.Println("Operation cancelled.")
-			return
+			return nil
 		}
 	} else {
 		fmt.Println("Force flag enabled, skipping confirmation...")
@@ -111,7 +111,6 @@ func HandleActivationListWithForce(ctx context.Context, client *td.Client, flags
 
 	fmt.Printf("Collecting activations from %d audiences...\n", len(audiences.Audiences))
 
-	// Collect activations from all audiences
 	var allActivations []td.CDPActivation
 	total := len(audiences.Audiences)
 	for i, audience := range audiences.Audiences {
@@ -121,7 +120,6 @@ func HandleActivationListWithForce(ctx context.Context, client *td.Client, flags
 
 		resp, err := client.CDP.ListActivations(ctx, audience.ID, nil)
 		if err != nil {
-			// Skip this audience if there's an error, but continue with others
 			if flags.Verbose {
 				fmt.Printf("Warning: Failed to get activations for audience %s: %v\n", audience.ID, err)
 			}
@@ -132,7 +130,6 @@ func HandleActivationListWithForce(ctx context.Context, client *td.Client, flags
 
 	fmt.Printf("Completed! Collected %d total activations from %d audiences.\n", len(allActivations), total)
 
-	// Create a response with all collected activations
 	resp := &td.CDPActivationListResponse{
 		Activations: allActivations,
 		Total:       int64(len(allActivations)),
@@ -140,7 +137,7 @@ func HandleActivationListWithForce(ctx context.Context, client *td.Client, flags
 
 	switch flags.Format {
 	case "json":
-		printJSON(resp)
+		return printJSON(resp)
 	case "csv":
 		fmt.Println("id,name,type,audience_id,status,created_at,updated_at")
 		for _, activation := range resp.Activations {
@@ -153,7 +150,7 @@ func HandleActivationListWithForce(ctx context.Context, client *td.Client, flags
 	default:
 		if len(resp.Activations) == 0 {
 			fmt.Println("No activations found")
-			return
+			return nil
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -166,27 +163,28 @@ func HandleActivationListWithForce(ctx context.Context, client *td.Client, flags
 		w.Flush()
 		fmt.Printf("\nTotal: %d activations\n", resp.Total)
 	}
+	return nil
 }
 
 // HandleActivationGet retrieves a specific activation
-func HandleActivationGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		handleUsageError("Usage: cdp activation get <audience-id> <segment-id> <activation-id>", flags.Verbose)
+		return usageError("Usage: cdp activation get <audience-id> <segment-id> <activation-id>")
 	}
 
 	activation, err := client.CDP.GetActivation(ctx, args[0], args[1], args[2])
 	if err != nil {
-		handleError(err, "Failed to get activation", flags.Verbose)
+		return wrapError(err, "failed to get activation", flags.Verbose)
 	}
 
-	printActivationDetails(activation, flags)
+	return printActivationDetails(activation, flags)
 }
 
 // printActivationDetails prints activation details in various formats
-func printActivationDetails(activation *td.CDPActivation, flags Flags) {
+func printActivationDetails(activation *td.CDPActivation, flags Flags) error {
 	switch flags.Format {
 	case "json":
-		printJSON(activation)
+		return printJSON(activation)
 	case "csv":
 		fmt.Println("id,name,type,audience_id,status,created_at,updated_at")
 		fmt.Printf("%s,%s,%s,%s,%s,%s,%s\n",
@@ -253,73 +251,74 @@ func printActivationDetails(activation *td.CDPActivation, flags Flags) {
 			}
 		}
 	}
+	return nil
 }
 
 // HandleActivationUpdateStatus updates activation status
-func HandleActivationUpdateStatus(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationUpdateStatus(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 4 {
-		handleUsageError("Usage: cdp activation update-status <audience-id> <segment-id> <activation-id> <status>", flags.Verbose)
+		return usageError("Usage: cdp activation update-status <audience-id> <segment-id> <activation-id> <status>")
 	}
 
-	_, err := client.CDP.UpdateActivationStatus(ctx, args[0], args[1], args[2], args[3])
-	if err != nil {
-		handleError(err, "Failed to update activation status", flags.Verbose)
+	if _, err := client.CDP.UpdateActivationStatus(ctx, args[0], args[1], args[2], args[3]); err != nil {
+		return wrapError(err, "failed to update activation status", flags.Verbose)
 	}
 
 	fmt.Printf("Activation status updated to '%s' successfully\n", args[3])
+	return nil
 }
 
 // HandleActivationUpdate updates an activation
-func HandleActivationUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 4 {
-		handleUsageError("Usage: cdp activation update <audience-id> <segment-id> <activation-id> <updates-json>", flags.Verbose)
+		return usageError("Usage: cdp activation update <audience-id> <segment-id> <activation-id> <updates-json>")
 	}
 
 	var updates td.CDPActivationUpdateRequest
-	err := json.Unmarshal([]byte(args[3]), &updates)
-	if err != nil {
-		handleUsageError(fmt.Sprintf("Invalid updates JSON: %v", err), flags.Verbose)
+	if err := json.Unmarshal([]byte(args[3]), &updates); err != nil {
+		return usageError(fmt.Sprintf("Invalid updates JSON: %v", err))
 	}
 
 	activation, err := client.CDP.UpdateActivation(ctx, args[0], args[1], args[2], &updates)
 	if err != nil {
-		handleError(err, "Failed to update activation", flags.Verbose)
+		return wrapError(err, "failed to update activation", flags.Verbose)
 	}
 
 	fmt.Printf("Activation updated successfully\n")
 	fmt.Printf("ID: %s\n", activation.ID)
 	fmt.Printf("Name: %s\n", activation.Name)
 	fmt.Printf("Status: %s\n", activation.Status)
+	return nil
 }
 
 // HandleActivationDelete deletes an activation
-func HandleActivationDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		handleUsageError("Usage: cdp activation delete <audience-id> <segment-id> <activation-id>", flags.Verbose)
+		return usageError("Usage: cdp activation delete <audience-id> <segment-id> <activation-id>")
 	}
 
-	err := client.CDP.DeleteActivation(ctx, args[0], args[1], args[2])
-	if err != nil {
-		handleError(err, "Failed to delete activation", flags.Verbose)
+	if err := client.CDP.DeleteActivation(ctx, args[0], args[1], args[2]); err != nil {
+		return wrapError(err, "failed to delete activation", flags.Verbose)
 	}
 
 	fmt.Printf("Activation %s deleted successfully\n", args[2])
+	return nil
 }
 
 // HandleActivationExecute executes an activation
-func HandleActivationExecute(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationExecute(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		handleUsageError("Usage: cdp activation execute <audience-id> <segment-id> <activation-id>", flags.Verbose)
+		return usageError("Usage: cdp activation execute <audience-id> <segment-id> <activation-id>")
 	}
 
 	execution, err := client.CDP.ExecuteActivation(ctx, args[0], args[1], args[2])
 	if err != nil {
-		handleError(err, "Failed to execute activation", flags.Verbose)
+		return wrapError(err, "failed to execute activation", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(execution)
+		return printJSON(execution)
 	case "csv":
 		fmt.Println("id,status,created_at")
 		fmt.Printf("%s,%s,%s\n", execution.ID, execution.Status, execution.CreatedAt.Format("2006-01-02 15:04:05"))
@@ -329,17 +328,18 @@ func HandleActivationExecute(ctx context.Context, client *td.Client, args []stri
 		fmt.Printf("Status: %s\n", execution.Status)
 		fmt.Printf("Created: %s\n", execution.CreatedAt.Format("2006-01-02 15:04:05"))
 	}
+	return nil
 }
 
 // HandleActivationGetExecutions gets activation execution history
-func HandleActivationGetExecutions(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationGetExecutions(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		handleUsageError("Usage: cdp activation executions <audience-id> <segment-id> <activation-id>", flags.Verbose)
+		return usageError("Usage: cdp activation executions <audience-id> <segment-id> <activation-id>")
 	}
 
 	executions, err := client.CDP.GetActivationExecutions(ctx, args[0], args[1], args[2])
 	if err != nil {
-		handleError(err, "Failed to get activation executions", flags.Verbose)
+		return wrapError(err, "failed to get activation executions", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -370,28 +370,29 @@ func HandleActivationGetExecutions(ctx context.Context, client *td.Client, args 
 	}
 
 	if err := formatAndWriteOutput(executions, flags.Format, flags.Output, "id,status,created_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleActivationListByAudience lists activations for a specific audience
-func HandleActivationListByAudience(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationListByAudience(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Audience ID required", flags.Verbose)
+		return usageError("Audience ID required")
 	}
 
 	resp, err := client.CDP.ListActivations(ctx, args[0], nil)
 	if err != nil {
-		// Enhanced error handling for common issues
-		if tdErr, ok := err.(*td.ErrorResponse); ok {
+		var tdErr *td.ErrorResponse
+		if errors.As(err, &tdErr) && tdErr.Response != nil {
 			switch tdErr.Response.StatusCode {
 			case 422:
-				handleUsageError(fmt.Sprintf("Invalid audience ID '%s'. Please use a valid audience ID.\n\nTo find valid audience IDs, run:\n  cdp audiences ls\n\nIf you want activations for a parent segment, use:\n  cdp activations list-by-parent-segment %s", args[0], args[0]), flags.Verbose)
+				return usageError(fmt.Sprintf("Invalid audience ID '%s'. Please use a valid audience ID.\n\nTo find valid audience IDs, run:\n  cdp audiences ls\n\nIf you want activations for a parent segment, use:\n  cdp activations list-by-parent-segment %s", args[0], args[0]))
 			case 404:
-				handleUsageError(fmt.Sprintf("Audience '%s' not found. Please check the audience ID and try again.\n\nTo find valid audience IDs, run:\n  cdp audiences ls", args[0]), flags.Verbose)
+				return usageError(fmt.Sprintf("Audience '%s' not found. Please check the audience ID and try again.\n\nTo find valid audience IDs, run:\n  cdp audiences ls", args[0]))
 			}
 		}
-		handleError(err, "Failed to list activations", flags.Verbose)
+		return wrapError(err, "failed to list activations", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -426,14 +427,15 @@ func HandleActivationListByAudience(ctx context.Context, client *td.Client, args
 	}
 
 	if err := formatAndWriteOutput(resp, flags.Format, flags.Output, "id,name,type,audience_id,status,created_at,updated_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleActivationListBySegmentFolder lists activations for a segment folder
-func HandleActivationListBySegmentFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationListBySegmentFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Segment folder ID required", flags.Verbose)
+		return usageError("Segment folder ID required")
 	}
 
 	opts := &td.CDPActivationListOptions{
@@ -443,7 +445,7 @@ func HandleActivationListBySegmentFolder(ctx context.Context, client *td.Client,
 
 	resp, err := client.CDP.GetSegmentFolderActivations(ctx, args[0], opts)
 	if err != nil {
-		handleError(err, "Failed to list activations for segment folder", flags.Verbose)
+		return wrapError(err, "failed to list activations for segment folder", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -478,24 +480,25 @@ func HandleActivationListBySegmentFolder(ctx context.Context, client *td.Client,
 	}
 
 	if err := formatAndWriteOutput(resp, flags.Format, flags.Output, "id,name,type,audience_id,status,created_at,updated_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleActivationRunForSegment runs activation for a segment
-func HandleActivationRunForSegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationRunForSegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp activation run-segment <segment-id> <activation-id>", flags.Verbose)
+		return usageError("Usage: cdp activation run-segment <segment-id> <activation-id>")
 	}
 
 	execution, err := client.CDP.RunSegmentActivation(ctx, args[0], args[1])
 	if err != nil {
-		handleError(err, "Failed to run activation for segment", flags.Verbose)
+		return wrapError(err, "failed to run activation for segment", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(execution)
+		return printJSON(execution)
 	case "csv":
 		fmt.Println("id,status,created_at")
 		fmt.Printf("%s,%s,%s\n", execution.ID, execution.Status, execution.CreatedAt.Format("2006-01-02 15:04:05"))
@@ -505,12 +508,13 @@ func HandleActivationRunForSegment(ctx context.Context, client *td.Client, args 
 		fmt.Printf("Status: %s\n", execution.Status)
 		fmt.Printf("Created: %s\n", execution.CreatedAt.Format("2006-01-02 15:04:05"))
 	}
+	return nil
 }
 
 // HandleActivationListByParentSegment lists activations for a parent segment
-func HandleActivationListByParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleActivationListByParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Parent segment ID required", flags.Verbose)
+		return usageError("Parent segment ID required")
 	}
 
 	opts := &td.CDPActivationListOptions{
@@ -520,7 +524,7 @@ func HandleActivationListByParentSegment(ctx context.Context, client *td.Client,
 
 	resp, err := client.CDP.GetParentSegmentActivations(ctx, args[0], opts)
 	if err != nil {
-		handleError(err, "Failed to list activations for parent segment", flags.Verbose)
+		return wrapError(err, "failed to list activations for parent segment", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -555,24 +559,25 @@ func HandleActivationListByParentSegment(ctx context.Context, client *td.Client,
 	}
 
 	if err := formatAndWriteOutput(resp, flags.Format, flags.Output, "id,name,type,audience_id,status,created_at,updated_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleGetMatchedActivationsForParentSegment gets matched activations for a parent segment
-func HandleGetMatchedActivationsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetMatchedActivationsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Parent segment ID required", flags.Verbose)
+		return usageError("Parent segment ID required")
 	}
 
 	resp, err := client.CDP.GetParentSegmentMatchedActivations(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get matched activations for parent segment", flags.Verbose)
+		return wrapError(err, "failed to get matched activations for parent segment", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(resp)
+		return printJSON(resp)
 	case "csv":
 		fmt.Println("id,name,type,status,created_at")
 		for _, activation := range resp.Activations {
@@ -583,7 +588,7 @@ func HandleGetMatchedActivationsForParentSegment(ctx context.Context, client *td
 	default:
 		if len(resp.Activations) == 0 {
 			fmt.Println("No matched activations found for parent segment")
-			return
+			return nil
 		}
 		fmt.Printf("Matched Activations for Parent Segment %s:\n", args[0])
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -596,22 +601,23 @@ func HandleGetMatchedActivationsForParentSegment(ctx context.Context, client *td
 		w.Flush()
 		fmt.Printf("\nTotal: %d matched activations\n", len(resp.Activations))
 	}
+	return nil
 }
 
 // HandleGetWorkflowProjectsForParentSegment gets workflow projects for a parent segment
-func HandleGetWorkflowProjectsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetWorkflowProjectsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Parent segment ID required", flags.Verbose)
+		return usageError("Parent segment ID required")
 	}
 
 	resp, err := client.CDP.GetParentSegmentUserDefinedWorkflowProjects(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get workflow projects for parent segment", flags.Verbose)
+		return wrapError(err, "failed to get workflow projects for parent segment", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(resp)
+		return printJSON(resp)
 	case "csv":
 		fmt.Println("id,name,status,created_at")
 		for _, project := range resp.Projects {
@@ -622,7 +628,7 @@ func HandleGetWorkflowProjectsForParentSegment(ctx context.Context, client *td.C
 	default:
 		if len(resp.Projects) == 0 {
 			fmt.Println("No workflow projects found for parent segment")
-			return
+			return nil
 		}
 		fmt.Printf("Workflow Projects for Parent Segment %s:\n", args[0])
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -635,22 +641,23 @@ func HandleGetWorkflowProjectsForParentSegment(ctx context.Context, client *td.C
 		w.Flush()
 		fmt.Printf("\nTotal: %d workflow projects\n", len(resp.Projects))
 	}
+	return nil
 }
 
 // HandleGetWorkflowsForParentSegment gets workflows for a parent segment
-func HandleGetWorkflowsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetWorkflowsForParentSegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp activations workflows <parent-segment-id> <workflow-project-name>", flags.Verbose)
+		return usageError("Usage: cdp activations workflows <parent-segment-id> <workflow-project-name>")
 	}
 
 	resp, err := client.CDP.GetParentSegmentUserDefinedWorkflows(ctx, args[0], args[1])
 	if err != nil {
-		handleError(err, "Failed to get workflows for parent segment", flags.Verbose)
+		return wrapError(err, "failed to get workflows for parent segment", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(resp)
+		return printJSON(resp)
 	case "csv":
 		fmt.Println("id,name,project_id,created_at")
 		for _, workflow := range resp.Workflows {
@@ -661,7 +668,7 @@ func HandleGetWorkflowsForParentSegment(ctx context.Context, client *td.Client, 
 	default:
 		if len(resp.Workflows) == 0 {
 			fmt.Println("No workflows found for parent segment")
-			return
+			return nil
 		}
 		fmt.Printf("Workflows for Parent Segment %s:\n", args[0])
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -674,4 +681,5 @@ func HandleGetWorkflowsForParentSegment(ctx context.Context, client *td.Client, 
 		w.Flush()
 		fmt.Printf("\nTotal: %d workflows\n", len(resp.Workflows))
 	}
+	return nil
 }

--- a/cmd/tdcli/cdp/audiences.go
+++ b/cmd/tdcli/cdp/audiences.go
@@ -11,26 +11,27 @@ import (
 )
 
 // HandleAudienceCreate creates a new CDP audience
-func HandleAudienceCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleAudienceCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 4 {
-		handleUsageError("Name, description, parent database name, and parent table name required", flags.Verbose)
+		return usageError("Name, description, parent database name, and parent table name required")
 	}
 
 	audience, err := client.CDP.CreateAudience(ctx, args[0], args[1], args[2], args[3])
 	if err != nil {
-		handleError(err, "Failed to create audience", flags.Verbose)
+		return wrapError(err, "failed to create audience", flags.Verbose)
 	}
 
 	fmt.Printf("Audience created successfully\n")
 	fmt.Printf("ID: %s\n", audience.ID)
 	fmt.Printf("Name: %s\n", audience.Name)
+	return nil
 }
 
 // HandleAudienceList lists all CDP audiences
-func HandleAudienceList(ctx context.Context, client *td.Client, flags Flags) {
+func HandleAudienceList(ctx context.Context, client *td.Client, flags Flags) error {
 	resp, err := client.CDP.ListAudiences(ctx)
 	if err != nil {
-		handleError(err, "Failed to list audiences", flags.Verbose)
+		return wrapError(err, "failed to list audiences", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -64,24 +65,25 @@ func HandleAudienceList(ctx context.Context, client *td.Client, flags Flags) {
 	}
 
 	if err := formatAndWriteOutput(resp, flags.Format, flags.Output, "id,name,population,schedule_type,created_at,updated_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleAudienceGet retrieves a specific CDP audience
-func HandleAudienceGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleAudienceGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Audience ID required", flags.Verbose)
+		return usageError("Audience ID required")
 	}
 
 	audience, err := client.CDP.GetAudience(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get audience", flags.Verbose)
+		return wrapError(err, "failed to get audience", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(audience)
+		return printJSON(audience)
 	case "csv":
 		fmt.Println("id,name,population,schedule_type,created_at,updated_at")
 		fmt.Printf("%s,%s,%d,%s,%s,%s\n",
@@ -113,36 +115,36 @@ func HandleAudienceGet(ctx context.Context, client *td.Client, args []string, fl
 			}
 		}
 	}
+	return nil
 }
 
 // HandleAudienceDelete deletes a CDP audience
-func HandleAudienceDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleAudienceDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Audience ID required", flags.Verbose)
+		return usageError("Audience ID required")
 	}
 
-	err := client.CDP.DeleteAudience(ctx, args[0])
-	if err != nil {
-		handleError(err, "Failed to delete audience", flags.Verbose)
+	if err := client.CDP.DeleteAudience(ctx, args[0]); err != nil {
+		return wrapError(err, "failed to delete audience", flags.Verbose)
 	}
 
 	fmt.Printf("Audience %s deleted successfully\n", args[0])
+	return nil
 }
 
 // HandleAudienceUpdate updates a CDP audience
-func HandleAudienceUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleAudienceUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp audience update <audience-id> <key=value>...", flags.Verbose)
+		return usageError("Usage: cdp audience update <audience-id> <key=value>...")
 	}
 
 	audienceID := args[0]
 	req := &td.CDPAudienceUpdateRequest{}
 
-	// Parse key=value pairs
 	for _, arg := range args[1:] {
 		parts := strings.SplitN(arg, "=", 2)
 		if len(parts) != 2 {
-			handleUsageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg), flags.Verbose)
+			return usageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg))
 		}
 		switch parts[0] {
 		case "name":
@@ -168,32 +170,33 @@ func HandleAudienceUpdate(ctx context.Context, client *td.Client, args []string,
 		case "presto_pool_name":
 			req.PrestoPoolName = &parts[1]
 		default:
-			handleUsageError(fmt.Sprintf("Unknown field: %s", parts[0]), flags.Verbose)
+			return usageError(fmt.Sprintf("Unknown field: %s", parts[0]))
 		}
 	}
 
 	audience, err := client.CDP.UpdateAudience(ctx, audienceID, req)
 	if err != nil {
-		handleError(err, "Failed to update audience", flags.Verbose)
+		return wrapError(err, "failed to update audience", flags.Verbose)
 	}
 
 	fmt.Printf("Audience %s updated successfully\n", audience.ID)
+	return nil
 }
 
 // HandleAudienceAttributes gets audience attributes
-func HandleAudienceAttributes(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleAudienceAttributes(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Audience ID required", flags.Verbose)
+		return usageError("Audience ID required")
 	}
 
 	attributes, err := client.CDP.GetAudienceAttributes(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get audience attributes", flags.Verbose)
+		return wrapError(err, "failed to get audience attributes", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(attributes)
+		return printJSON(attributes)
 	case "csv":
 		fmt.Println("name,type,parent_database_name,parent_table_name,parent_column")
 		for _, attr := range attributes {
@@ -206,7 +209,7 @@ func HandleAudienceAttributes(ctx context.Context, client *td.Client, args []str
 	default:
 		if len(attributes) == 0 {
 			fmt.Println("No attributes found")
-			return
+			return nil
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -221,22 +224,23 @@ func HandleAudienceAttributes(ctx context.Context, client *td.Client, args []str
 		w.Flush()
 		fmt.Printf("\nTotal: %d attributes\n", len(attributes))
 	}
+	return nil
 }
 
 // HandleAudienceBehaviors gets audience behaviors
-func HandleAudienceBehaviors(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleAudienceBehaviors(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Audience ID required", flags.Verbose)
+		return usageError("Audience ID required")
 	}
 
 	behaviors, err := client.CDP.GetAudienceBehaviors(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get audience behaviors", flags.Verbose)
+		return wrapError(err, "failed to get audience behaviors", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(behaviors)
+		return printJSON(behaviors)
 	case "csv":
 		fmt.Println("id,name")
 		for _, behavior := range behaviors {
@@ -245,7 +249,7 @@ func HandleAudienceBehaviors(ctx context.Context, client *td.Client, args []stri
 	default:
 		if len(behaviors) == 0 {
 			fmt.Println("No behaviors found")
-			return
+			return nil
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -256,34 +260,36 @@ func HandleAudienceBehaviors(ctx context.Context, client *td.Client, args []stri
 		w.Flush()
 		fmt.Printf("\nTotal: %d behaviors\n", len(behaviors))
 	}
+	return nil
 }
 
 // HandleAudienceRun runs an audience execution
-func HandleAudienceRun(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleAudienceRun(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Audience ID required", flags.Verbose)
+		return usageError("Audience ID required")
 	}
 
 	execution, err := client.CDP.RunAudience(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to run audience", flags.Verbose)
+		return wrapError(err, "failed to run audience", flags.Verbose)
 	}
 
 	fmt.Printf("Audience execution started successfully\n")
 	fmt.Printf("Audience ID: %s\n", execution.AudienceID)
 	fmt.Printf("Status: %s\n", execution.Status)
 	fmt.Printf("Created: %s\n", execution.CreatedAt.Format("2006-01-02 15:04:05"))
+	return nil
 }
 
 // HandleAudienceExecutions gets audience execution history
-func HandleAudienceExecutions(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleAudienceExecutions(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Audience ID required", flags.Verbose)
+		return usageError("Audience ID required")
 	}
 
 	executions, err := client.CDP.GetAudienceExecutions(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get audience executions", flags.Verbose)
+		return wrapError(err, "failed to get audience executions", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -314,24 +320,25 @@ func HandleAudienceExecutions(ctx context.Context, client *td.Client, args []str
 	}
 
 	if err := formatAndWriteOutput(executions, flags.Format, flags.Output, "audience_id,status,created_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleAudienceStatistics gets audience statistics
-func HandleAudienceStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleAudienceStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Audience ID required", flags.Verbose)
+		return usageError("Audience ID required")
 	}
 
 	stats, err := client.CDP.GetAudienceStatistics(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get audience statistics", flags.Verbose)
+		return wrapError(err, "failed to get audience statistics", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(stats)
+		return printJSON(stats)
 	case "csv":
 		fmt.Println("data_point")
 		for _, point := range stats {
@@ -340,7 +347,7 @@ func HandleAudienceStatistics(ctx context.Context, client *td.Client, args []str
 	default:
 		if len(stats) == 0 {
 			fmt.Println("No statistics available")
-			return
+			return nil
 		}
 
 		fmt.Printf("Statistics data points:\n")
@@ -349,22 +356,23 @@ func HandleAudienceStatistics(ctx context.Context, client *td.Client, args []str
 		}
 		fmt.Printf("\nTotal data points: %d\n", len(stats))
 	}
+	return nil
 }
 
 // HandleAudienceSampleValues gets audience sample values
-func HandleAudienceSampleValues(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleAudienceSampleValues(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Audience ID and attribute name required", flags.Verbose)
+		return usageError("Audience ID and attribute name required")
 	}
 
 	values, err := client.CDP.GetAudienceSampleValues(ctx, args[0], args[1])
 	if err != nil {
-		handleError(err, "Failed to get sample values", flags.Verbose)
+		return wrapError(err, "failed to get sample values", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(values)
+		return printJSON(values)
 	case "csv":
 		fmt.Println("value")
 		for _, value := range values {
@@ -373,7 +381,7 @@ func HandleAudienceSampleValues(ctx context.Context, client *td.Client, args []s
 	default:
 		if len(values) == 0 {
 			fmt.Println("No sample values found")
-			return
+			return nil
 		}
 
 		fmt.Printf("Sample values for attribute '%s':\n", args[1])
@@ -382,22 +390,23 @@ func HandleAudienceSampleValues(ctx context.Context, client *td.Client, args []s
 		}
 		fmt.Printf("\nTotal: %d values\n", len(values))
 	}
+	return nil
 }
 
 // HandleAudienceBehaviorSamples gets behavior sample values
-func HandleAudienceBehaviorSamples(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleAudienceBehaviorSamples(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		handleUsageError("Usage: cdp audience behavior-samples <audience-id> <behavior-id> <column>", flags.Verbose)
+		return usageError("Usage: cdp audience behavior-samples <audience-id> <behavior-id> <column>")
 	}
 
 	samples, err := client.CDP.GetAudienceBehaviorSampleValues(ctx, args[0], args[1], args[2])
 	if err != nil {
-		handleError(err, "Failed to get audience behavior sample values", flags.Verbose)
+		return wrapError(err, "failed to get audience behavior sample values", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(samples)
+		return printJSON(samples)
 	case "csv":
 		fmt.Println("value,frequency")
 		for _, sample := range samples {
@@ -408,7 +417,7 @@ func HandleAudienceBehaviorSamples(ctx context.Context, client *td.Client, args 
 	default:
 		if len(samples) == 0 {
 			fmt.Println("No sample values found")
-			return
+			return nil
 		}
 		fmt.Printf("Sample Values for Behavior %s, Column %s:\n", args[1], args[2])
 		for _, sample := range samples {
@@ -418,4 +427,5 @@ func HandleAudienceBehaviorSamples(ctx context.Context, client *td.Client, args 
 		}
 		fmt.Printf("\nTotal: %d samples\n", len(samples))
 	}
+	return nil
 }

--- a/cmd/tdcli/cdp/common.go
+++ b/cmd/tdcli/cdp/common.go
@@ -2,8 +2,8 @@ package cdp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
@@ -32,57 +32,43 @@ type Flags struct {
 	CAFile             string
 }
 
-// CaptureErrors signals handleError to panic instead of calling log.Fatalf.
-// Set by the main package's runHandlerWithErrorCapture when wrapping commands.
-var CaptureErrors = false
-
-// handleError handles errors with optional verbose output
-func handleError(err error, message string, verbose bool) {
-	if err != nil {
-		if CaptureErrors {
-			if verbose {
-				panic(fmt.Errorf("%s: %v", message, err))
-			}
-			panic(err)
-		}
+// wrapError returns a formatted error suitable for propagating up to the
+// caller. When verbose, it includes status/message details for TD API errors.
+func wrapError(err error, message string, verbose bool) error {
+	if err == nil {
+		return nil
 	}
 	if verbose {
-		if tdErr, ok := err.(*td.ErrorResponse); ok {
-			log.Fatalf("%s: %v (Status: %d, Message: %s)", message, err, tdErr.Response.StatusCode, tdErr.Message)
+		var tdErr *td.ErrorResponse
+		if errors.As(err, &tdErr) && tdErr.Response != nil {
+			return fmt.Errorf("%s: %w (status: %d, message: %s)", message, err, tdErr.Response.StatusCode, tdErr.Message)
 		}
 	}
-	log.Fatalf("%s: %v", message, err)
+	return fmt.Errorf("%s: %w", message, err)
 }
 
-// HandleError is an exported version of handleError for use in other files
-func HandleError(err error, verbose bool) {
-	handleError(err, "Operation failed", verbose)
+// usageError builds a usage-failure error for a missing/invalid arg.
+func usageError(message string) error {
+	return errors.New(message)
 }
 
-// handleUsageError handles usage errors with consistent formatting
-func handleUsageError(usageMessage string, verbose bool) {
-	if verbose {
-		log.Fatalf("Usage error: %s", usageMessage)
-	}
-	log.Fatalf("%s", usageMessage)
-}
-
-// FormatOutput formats and outputs data using JSON by default
-func FormatOutput(data interface{}, format, output string) {
-	switch format {
-	case "json":
-		printJSON(data)
-	default:
-		printJSON(data) // Default to JSON for new commands
-	}
-}
-
-// printJSON prints data as JSON
-func printJSON(data interface{}) {
+// printJSON encodes data as indented JSON to stdout.
+func printJSON(data interface{}) error {
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(data); err != nil {
-		log.Fatalf("Failed to encode JSON: %v", err)
+		return fmt.Errorf("failed to encode JSON: %w", err)
+	}
+	return nil
+}
+
+// FormatOutput formats and outputs data using JSON by default.
+func FormatOutput(data interface{}, format, output string) error {
+	switch format {
+	case "json":
+		return printJSON(data)
+	default:
+		return printJSON(data)
 	}
 }
 

--- a/cmd/tdcli/cdp/folders.go
+++ b/cmd/tdcli/cdp/folders.go
@@ -11,9 +11,9 @@ import (
 )
 
 // HandleCreateAudienceFolder creates a new audience folder
-func HandleCreateAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleCreateAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Audience ID and folder name required", flags.Verbose)
+		return usageError("Audience ID and folder name required")
 	}
 
 	req := &td.CDPAudienceFolderCreateRequest{
@@ -28,29 +28,29 @@ func HandleCreateAudienceFolder(ctx context.Context, client *td.Client, args []s
 
 	folder, err := client.CDP.CreateAudienceFolder(ctx, args[0], req)
 	if err != nil {
-		handleError(err, "Failed to create audience folder", flags.Verbose)
+		return wrapError(err, "failed to create audience folder", flags.Verbose)
 	}
 
 	fmt.Printf("Audience folder created successfully\n")
 	fmt.Printf("ID: %s\n", folder.ID)
 	fmt.Printf("Name: %s\n", folder.Name)
+	return nil
 }
 
 // HandleUpdateAudienceFolder updates an audience folder
-func HandleUpdateAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleUpdateAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		handleUsageError("Usage: cdp folder update <audience-id> <folder-id> <key=value>...", flags.Verbose)
+		return usageError("Usage: cdp folder update <audience-id> <folder-id> <key=value>...")
 	}
 
 	audienceID := args[0]
 	folderID := args[1]
 	req := &td.CDPAudienceFolderUpdateRequest{}
 
-	// Parse key=value pairs
 	for _, arg := range args[2:] {
 		parts := strings.SplitN(arg, "=", 2)
 		if len(parts) != 2 {
-			handleUsageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg), flags.Verbose)
+			return usageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg))
 		}
 		switch parts[0] {
 		case "name":
@@ -58,46 +58,47 @@ func HandleUpdateAudienceFolder(ctx context.Context, client *td.Client, args []s
 		case "description":
 			req.Description = parts[1]
 		default:
-			handleUsageError(fmt.Sprintf("Unknown field: %s", parts[0]), flags.Verbose)
+			return usageError(fmt.Sprintf("Unknown field: %s", parts[0]))
 		}
 	}
 
 	folder, err := client.CDP.UpdateAudienceFolder(ctx, audienceID, folderID, req)
 	if err != nil {
-		handleError(err, "Failed to update audience folder", flags.Verbose)
+		return wrapError(err, "failed to update audience folder", flags.Verbose)
 	}
 
 	fmt.Printf("Audience folder %s updated successfully\n", folder.ID)
+	return nil
 }
 
 // HandleDeleteAudienceFolder deletes an audience folder
-func HandleDeleteAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleDeleteAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp folder delete <audience-id> <folder-id>", flags.Verbose)
+		return usageError("Usage: cdp folder delete <audience-id> <folder-id>")
 	}
 
-	err := client.CDP.DeleteAudienceFolder(ctx, args[0], args[1])
-	if err != nil {
-		handleError(err, "Failed to delete audience folder", flags.Verbose)
+	if err := client.CDP.DeleteAudienceFolder(ctx, args[0], args[1]); err != nil {
+		return wrapError(err, "failed to delete audience folder", flags.Verbose)
 	}
 
 	fmt.Printf("Audience folder %s deleted successfully\n", args[1])
+	return nil
 }
 
 // HandleGetAudienceFolder gets an audience folder
-func HandleGetAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetAudienceFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Audience ID and folder ID required", flags.Verbose)
+		return usageError("Audience ID and folder ID required")
 	}
 
 	folder, err := client.CDP.GetAudienceFolder(ctx, args[0], args[1])
 	if err != nil {
-		handleError(err, "Failed to get audience folder", flags.Verbose)
+		return wrapError(err, "failed to get audience folder", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(folder)
+		return printJSON(folder)
 	case "csv":
 		fmt.Println("id,audience_id,name,description,parent_id,created_at,updated_at")
 		parentID := ""
@@ -126,17 +127,18 @@ func HandleGetAudienceFolder(ctx context.Context, client *td.Client, args []stri
 		fmt.Printf("Created: %s\n", folder.CreatedAt.Format("2006-01-02 15:04:05"))
 		fmt.Printf("Updated: %s\n", folder.UpdatedAt.Format("2006-01-02 15:04:05"))
 	}
+	return nil
 }
 
 // HandleListFolders lists all folders in an audience
-func HandleListFolders(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleListFolders(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Audience ID required", flags.Verbose)
+		return usageError("Audience ID required")
 	}
 
 	resp, err := client.CDP.ListFolders(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to list folders", flags.Verbose)
+		return wrapError(err, "failed to list folders", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -186,14 +188,15 @@ func HandleListFolders(ctx context.Context, client *td.Client, args []string, fl
 	}
 
 	if err := formatAndWriteOutput(resp, flags.Format, flags.Output, "id,audience_id,name,description,parent_folder_id,created_at,updated_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleCreateEntityFolder creates an entity folder
-func HandleCreateEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleCreateEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Folder name required", flags.Verbose)
+		return usageError("Folder name required")
 	}
 
 	req := &td.CDPFolderCreateRequest{
@@ -208,28 +211,29 @@ func HandleCreateEntityFolder(ctx context.Context, client *td.Client, args []str
 
 	folder, err := client.CDP.CreateEntityFolder(ctx, req)
 	if err != nil {
-		handleError(err, "Failed to create entity folder", flags.Verbose)
+		return wrapError(err, "failed to create entity folder", flags.Verbose)
 	}
 
 	fmt.Printf("Entity folder created successfully\n")
 	fmt.Printf("ID: %s\n", folder.ID)
 	fmt.Printf("Name: %s\n", folder.Name)
+	return nil
 }
 
 // HandleGetEntityFolder gets an entity folder
-func HandleGetEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Folder ID required", flags.Verbose)
+		return usageError("Folder ID required")
 	}
 
 	folder, err := client.CDP.GetEntityFolder(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get entity folder", flags.Verbose)
+		return wrapError(err, "failed to get entity folder", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(folder)
+		return printJSON(folder)
 	default:
 		if dataMap, ok := folder.Data.(map[string]interface{}); ok {
 			if id, exists := dataMap["id"]; exists {
@@ -257,22 +261,22 @@ func HandleGetEntityFolder(ctx context.Context, client *td.Client, args []string
 			}
 		}
 	}
+	return nil
 }
 
 // HandleUpdateEntityFolder updates an entity folder
-func HandleUpdateEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleUpdateEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp folder update-entity <folder-id> <key=value>...", flags.Verbose)
+		return usageError("Usage: cdp folder update-entity <folder-id> <key=value>...")
 	}
 
 	folderID := args[0]
 	req := &td.CDPFolderUpdateRequest{}
 
-	// Parse key=value pairs
 	for _, arg := range args[1:] {
 		parts := strings.SplitN(arg, "=", 2)
 		if len(parts) != 2 {
-			handleUsageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg), flags.Verbose)
+			return usageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg))
 		}
 		switch parts[0] {
 		case "name":
@@ -280,48 +284,49 @@ func HandleUpdateEntityFolder(ctx context.Context, client *td.Client, args []str
 		case "description":
 			req.Description = parts[1]
 		default:
-			handleUsageError(fmt.Sprintf("Unknown field: %s", parts[0]), flags.Verbose)
+			return usageError(fmt.Sprintf("Unknown field: %s", parts[0]))
 		}
 	}
 
 	folder, err := client.CDP.UpdateEntityFolder(ctx, folderID, req)
 	if err != nil {
-		handleError(err, "Failed to update entity folder", flags.Verbose)
+		return wrapError(err, "failed to update entity folder", flags.Verbose)
 	}
 
 	fmt.Printf("Entity folder %s updated successfully\n", folder.ID)
+	return nil
 }
 
 // HandleDeleteEntityFolder deletes an entity folder
-func HandleDeleteEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleDeleteEntityFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Folder ID required", flags.Verbose)
+		return usageError("Folder ID required")
 	}
 
-	err := client.CDP.DeleteEntityFolder(ctx, args[0])
-	if err != nil {
-		handleError(err, "Failed to delete entity folder", flags.Verbose)
+	if err := client.CDP.DeleteEntityFolder(ctx, args[0]); err != nil {
+		return wrapError(err, "failed to delete entity folder", flags.Verbose)
 	}
 
 	fmt.Printf("Entity folder %s deleted successfully\n", args[0])
+	return nil
 }
 
 // HandleGetEntitiesByFolder gets entities in a folder
-func HandleGetEntitiesByFolder(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetEntitiesByFolder(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Folder ID required", flags.Verbose)
+		return usageError("Folder ID required")
 	}
 
 	folderID := args[0]
 
 	entities, err := client.CDP.GetEntitiesByFolder(ctx, folderID)
 	if err != nil {
-		handleError(err, "Failed to get entities by folder", flags.Verbose)
+		return wrapError(err, "failed to get entities by folder", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(entities)
+		return printJSON(entities)
 	case "csv":
 		fmt.Println("id,type,name")
 		for _, entity := range entities.Data {
@@ -336,7 +341,7 @@ func HandleGetEntitiesByFolder(ctx context.Context, client *td.Client, args []st
 	default:
 		if len(entities.Data) == 0 {
 			fmt.Println("No entities found in folder")
-			return
+			return nil
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -353,4 +358,5 @@ func HandleGetEntitiesByFolder(ctx context.Context, client *td.Client, args []st
 		w.Flush()
 		fmt.Printf("\nTotal: %d entities\n", len(entities.Data))
 	}
+	return nil
 }

--- a/cmd/tdcli/cdp/funnels.go
+++ b/cmd/tdcli/cdp/funnels.go
@@ -12,14 +12,14 @@ import (
 )
 
 // HandleListFunnels lists CDP funnels
-func HandleListFunnels(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleListFunnels(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Audience ID required", flags.Verbose)
+		return usageError("Audience ID required")
 	}
 
 	funnels, err := client.CDP.ListFunnels(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to list funnels", flags.Verbose)
+		return wrapError(err, "failed to list funnels", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -54,20 +54,20 @@ func HandleListFunnels(ctx context.Context, client *td.Client, args []string, fl
 	}
 
 	if err := formatAndWriteOutput(funnels, flags.Format, flags.Output, "id,name,created_at,updated_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleCreateFunnel creates a new CDP funnel
-func HandleCreateFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleCreateFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		handleUsageError("Usage: cdp funnel create <audience-id> <name> <steps-json>", flags.Verbose)
+		return usageError("Usage: cdp funnel create <audience-id> <name> <steps-json>")
 	}
 
 	var stages []td.CDPFunnelStage
-	err := json.Unmarshal([]byte(args[2]), &stages)
-	if err != nil {
-		handleUsageError(fmt.Sprintf("Invalid stages JSON: %v", err), flags.Verbose)
+	if err := json.Unmarshal([]byte(args[2]), &stages); err != nil {
+		return usageError(fmt.Sprintf("Invalid stages JSON: %v", err))
 	}
 
 	req := td.CDPFunnelCreateRequest{
@@ -77,28 +77,29 @@ func HandleCreateFunnel(ctx context.Context, client *td.Client, args []string, f
 
 	funnel, err := client.CDP.CreateFunnel(ctx, args[0], req)
 	if err != nil {
-		handleError(err, "Failed to create funnel", flags.Verbose)
+		return wrapError(err, "failed to create funnel", flags.Verbose)
 	}
 
 	fmt.Printf("Funnel created successfully\n")
 	fmt.Printf("ID: %s\n", funnel.ID)
 	fmt.Printf("Name: %s\n", funnel.Name)
+	return nil
 }
 
 // HandleGetFunnel retrieves a specific funnel
-func HandleGetFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp funnel get <audience-id> <funnel-id>", flags.Verbose)
+		return usageError("Usage: cdp funnel get <audience-id> <funnel-id>")
 	}
 
 	funnel, err := client.CDP.GetFunnel(ctx, args[0], args[1])
 	if err != nil {
-		handleError(err, "Failed to get funnel", flags.Verbose)
+		return wrapError(err, "failed to get funnel", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(funnel)
+		return printJSON(funnel)
 	case "csv":
 		fmt.Println("id,name,step_count,created_at,updated_at")
 		fmt.Printf("%s,%s,%d,%s,%s\n",
@@ -118,18 +119,18 @@ func HandleGetFunnel(ctx context.Context, client *td.Client, args []string, flag
 			}
 		}
 	}
+	return nil
 }
 
 // HandleUpdateFunnel updates a funnel
-func HandleUpdateFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleUpdateFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 4 {
-		handleUsageError("Usage: cdp funnel update <audience-id> <funnel-id> <name> <steps-json>", flags.Verbose)
+		return usageError("Usage: cdp funnel update <audience-id> <funnel-id> <name> <steps-json>")
 	}
 
 	var stages []td.CDPFunnelStage
-	err := json.Unmarshal([]byte(args[3]), &stages)
-	if err != nil {
-		handleUsageError(fmt.Sprintf("Invalid stages JSON: %v", err), flags.Verbose)
+	if err := json.Unmarshal([]byte(args[3]), &stages); err != nil {
+		return usageError(fmt.Sprintf("Invalid stages JSON: %v", err))
 	}
 
 	req := td.CDPFunnelCreateRequest{
@@ -139,30 +140,31 @@ func HandleUpdateFunnel(ctx context.Context, client *td.Client, args []string, f
 
 	funnel, err := client.CDP.UpdateFunnel(ctx, args[0], args[1], req)
 	if err != nil {
-		handleError(err, "Failed to update funnel", flags.Verbose)
+		return wrapError(err, "failed to update funnel", flags.Verbose)
 	}
 
 	fmt.Printf("Funnel %s updated successfully\n", funnel.ID)
+	return nil
 }
 
 // HandleDeleteFunnel deletes a funnel
-func HandleDeleteFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleDeleteFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp funnel delete <audience-id> <funnel-id>", flags.Verbose)
+		return usageError("Usage: cdp funnel delete <audience-id> <funnel-id>")
 	}
 
-	_, err := client.CDP.DeleteFunnel(ctx, args[0], args[1])
-	if err != nil {
-		handleError(err, "Failed to delete funnel", flags.Verbose)
+	if _, err := client.CDP.DeleteFunnel(ctx, args[0], args[1]); err != nil {
+		return wrapError(err, "failed to delete funnel", flags.Verbose)
 	}
 
 	fmt.Printf("Funnel %s deleted successfully\n", args[1])
+	return nil
 }
 
 // HandleCloneFunnel clones a funnel
-func HandleCloneFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleCloneFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		handleUsageError("Usage: cdp funnel clone <audience-id> <funnel-id> <new-name>", flags.Verbose)
+		return usageError("Usage: cdp funnel clone <audience-id> <funnel-id> <new-name>")
 	}
 
 	req := td.CDPFunnelCloneRequest{
@@ -170,28 +172,29 @@ func HandleCloneFunnel(ctx context.Context, client *td.Client, args []string, fl
 	}
 	funnel, err := client.CDP.CloneFunnel(ctx, args[0], args[1], req)
 	if err != nil {
-		handleError(err, "Failed to clone funnel", flags.Verbose)
+		return wrapError(err, "failed to clone funnel", flags.Verbose)
 	}
 
 	fmt.Printf("Funnel cloned successfully\n")
 	fmt.Printf("New Funnel ID: %s\n", funnel.ID)
 	fmt.Printf("Name: %s\n", funnel.Name)
+	return nil
 }
 
 // HandleGetFunnelStatistics gets funnel statistics
-func HandleGetFunnelStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetFunnelStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp funnel statistics <audience-id> <funnel-id>", flags.Verbose)
+		return usageError("Usage: cdp funnel statistics <audience-id> <funnel-id>")
 	}
 
 	stats, err := client.CDP.GetFunnelStatistics(ctx, args[0], args[1], nil)
 	if err != nil {
-		handleError(err, "Failed to get funnel statistics", flags.Verbose)
+		return wrapError(err, "failed to get funnel statistics", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(stats)
+		return printJSON(stats)
 	case "csv":
 		fmt.Println("stage_id,history_count")
 		for _, stage := range stats.Stages {
@@ -211,12 +214,13 @@ func HandleGetFunnelStatistics(ctx context.Context, client *td.Client, args []st
 			w.Flush()
 		}
 	}
+	return nil
 }
 
 // HandleCreateEntityFunnel creates a new entity funnel
-func HandleCreateEntityFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleCreateEntityFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp funnel create-entity <name> [description]", flags.Verbose)
+		return usageError("Usage: cdp funnel create-entity <name> [description]")
 	}
 
 	desc := ""
@@ -229,13 +233,13 @@ func HandleCreateEntityFunnel(ctx context.Context, client *td.Client, args []str
 		Attributes: td.CDPFunnelEntityAttributes{
 			Name:        args[0],
 			Description: &desc,
-			Stages:      []td.CDPFunnelStageEntity{}, // Empty stages for now
+			Stages:      []td.CDPFunnelStageEntity{},
 		},
 	}
 
 	funnel, err := client.CDP.CreateEntityFunnel(ctx, req)
 	if err != nil {
-		handleError(err, "Failed to create entity funnel", flags.Verbose)
+		return wrapError(err, "failed to create entity funnel", flags.Verbose)
 	}
 
 	if dataMap, ok := funnel.Data.(map[string]interface{}); ok {
@@ -249,22 +253,23 @@ func HandleCreateEntityFunnel(ctx context.Context, client *td.Client, args []str
 			}
 		}
 	}
+	return nil
 }
 
 // HandleGetEntityFunnel retrieves an entity funnel
-func HandleGetEntityFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetEntityFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Usage: cdp funnel get-entity <funnel-id>", flags.Verbose)
+		return usageError("Usage: cdp funnel get-entity <funnel-id>")
 	}
 
 	funnel, err := client.CDP.GetEntityFunnel(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get entity funnel", flags.Verbose)
+		return wrapError(err, "failed to get entity funnel", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(funnel)
+		return printJSON(funnel)
 	default:
 		if dataMap, ok := funnel.Data.(map[string]interface{}); ok {
 			if id, exists := dataMap["id"]; exists {
@@ -289,26 +294,25 @@ func HandleGetEntityFunnel(ctx context.Context, client *td.Client, args []string
 			}
 		}
 	}
+	return nil
 }
 
 // HandleUpdateEntityFunnel updates an entity funnel
-func HandleUpdateEntityFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleUpdateEntityFunnel(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Usage: cdp funnel update-entity <funnel-id> [key=value...]", flags.Verbose)
+		return usageError("Usage: cdp funnel update-entity <funnel-id> [key=value...]")
 	}
 
 	updates := make(map[string]interface{})
 
-	// Parse key=value pairs from remaining arguments
 	for _, arg := range args[1:] {
 		parts := strings.SplitN(arg, "=", 2)
 		if len(parts) != 2 {
-			handleUsageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg), flags.Verbose)
+			return usageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg))
 		}
 		updates[parts[0]] = parts[1]
 	}
 
-	// Parse flags for updates
 	if flags.Name != "" {
 		updates["name"] = flags.Name
 	}
@@ -318,7 +322,7 @@ func HandleUpdateEntityFunnel(ctx context.Context, client *td.Client, args []str
 
 	funnel, err := client.CDP.UpdateEntityFunnel(ctx, args[0], updates)
 	if err != nil {
-		handleError(err, "Failed to update entity funnel", flags.Verbose)
+		return wrapError(err, "failed to update entity funnel", flags.Verbose)
 	}
 
 	if dataMap, ok := funnel.Data.(map[string]interface{}); ok {
@@ -326,4 +330,5 @@ func HandleUpdateEntityFunnel(ctx context.Context, client *td.Client, args []str
 			fmt.Printf("Entity funnel %s updated successfully\n", id)
 		}
 	}
+	return nil
 }

--- a/cmd/tdcli/cdp/journeys.go
+++ b/cmd/tdcli/cdp/journeys.go
@@ -13,205 +13,170 @@ import (
 )
 
 // HandleJourneyList handles journey listing by folder
-func HandleJourneyList(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Folder ID is required", flags.Verbose)
+		return usageError("Folder ID is required")
 	}
 
-	folderID := args[0]
-
-	journeys, err := client.CDP.ListJourneys(ctx, folderID)
+	journeys, err := client.CDP.ListJourneys(ctx, args[0])
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to list journeys", flags.Verbose)
 	}
 
-	FormatOutput(journeys, flags.Format, flags.Output)
+	return FormatOutput(journeys, flags.Format, flags.Output)
 }
 
 // HandleJourneyCreate handles journey creation
-func HandleJourneyCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Request file is required", flags.Verbose)
+		return usageError("Request file is required")
 	}
 
-	requestFile := args[0]
-
-	// Read the request file
-	requestData, err := os.ReadFile(requestFile)
+	requestData, err := os.ReadFile(args[0])
 	if err != nil {
-		handleUsageError(fmt.Sprintf("Error reading request file: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error reading request file: %v", err))
 	}
 
-	// Parse the request
 	var request td.CDPJourneyRequest
 	if err := json.Unmarshal(requestData, &request); err != nil {
-		handleUsageError(fmt.Sprintf("Error parsing request JSON: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error parsing request JSON: %v", err))
 	}
 
 	journey, err := client.CDP.CreateJourney(ctx, &request)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to create journey", flags.Verbose)
 	}
 
-	FormatOutput(journey, flags.Format, flags.Output)
+	return FormatOutput(journey, flags.Format, flags.Output)
 }
 
 // HandleJourneyGet handles getting journey details
-func HandleJourneyGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
-	journeyID := args[0]
-
-	journey, err := client.CDP.GetJourney(ctx, journeyID)
+	journey, err := client.CDP.GetJourney(ctx, args[0])
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to get journey", flags.Verbose)
 	}
 
-	FormatOutput(journey, flags.Format, flags.Output)
+	return FormatOutput(journey, flags.Format, flags.Output)
 }
 
 // HandleJourneyUpdate handles journey updates
-func HandleJourneyUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Error: Journey ID and request file are required", flags.Verbose)
+		return usageError("Journey ID and request file are required")
 	}
 
-	journeyID := args[0]
-	requestFile := args[1]
-
-	// Read the request file
-	requestData, err := os.ReadFile(requestFile)
+	requestData, err := os.ReadFile(args[1])
 	if err != nil {
-		handleUsageError(fmt.Sprintf("Error reading request file: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error reading request file: %v", err))
 	}
 
-	// Parse the request
 	var request td.CDPJourneyRequest
 	if err := json.Unmarshal(requestData, &request); err != nil {
-		handleUsageError(fmt.Sprintf("Error parsing request JSON: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error parsing request JSON: %v", err))
 	}
 
-	journey, err := client.CDP.UpdateJourney(ctx, journeyID, &request)
+	journey, err := client.CDP.UpdateJourney(ctx, args[0], &request)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to update journey", flags.Verbose)
 	}
 
-	FormatOutput(journey, flags.Format, flags.Output)
+	return FormatOutput(journey, flags.Format, flags.Output)
 }
 
 // HandleJourneyDelete handles journey deletion
-func HandleJourneyDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
-	journeyID := args[0]
-
-	err := client.CDP.DeleteJourney(ctx, journeyID)
-	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+	if err := client.CDP.DeleteJourney(ctx, args[0]); err != nil {
+		return wrapError(err, "failed to delete journey", flags.Verbose)
 	}
 
-	fmt.Printf("Journey %s deleted successfully\n", journeyID)
+	fmt.Printf("Journey %s deleted successfully\n", args[0])
+	return nil
 }
 
 // HandleJourneyDetail handles getting journey detail
-func HandleJourneyDetail(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyDetail(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
-	journeyID := args[0]
-
-	journey, err := client.CDP.GetJourneyDetail(ctx, journeyID)
+	journey, err := client.CDP.GetJourneyDetail(ctx, args[0])
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to get journey detail", flags.Verbose)
 	}
 
-	FormatOutput(journey, flags.Format, flags.Output)
+	return FormatOutput(journey, flags.Format, flags.Output)
 }
 
 // HandleJourneyDuplicate handles journey duplication
-func HandleJourneyDuplicate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyDuplicate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Request file is required", flags.Verbose)
+		return usageError("Request file is required")
 	}
 
-	requestFile := args[0]
-
-	// Read the request file
-	requestData, err := os.ReadFile(requestFile)
+	requestData, err := os.ReadFile(args[0])
 	if err != nil {
-		handleUsageError(fmt.Sprintf("Error reading request file: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error reading request file: %v", err))
 	}
 
-	// Parse the request
 	var request td.CDPJourneyDuplicateRequest
 	if err := json.Unmarshal(requestData, &request); err != nil {
-		handleUsageError(fmt.Sprintf("Error parsing request JSON: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error parsing request JSON: %v", err))
 	}
 
 	journey, err := client.CDP.DuplicateJourney(ctx, &request)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to duplicate journey", flags.Verbose)
 	}
 
-	FormatOutput(journey, flags.Format, flags.Output)
+	return FormatOutput(journey, flags.Format, flags.Output)
 }
 
 // HandleJourneyPause handles journey pausing
-func HandleJourneyPause(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyPause(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
-	journeyID := args[0]
-
-	journey, err := client.CDP.PauseJourney(ctx, journeyID)
+	journey, err := client.CDP.PauseJourney(ctx, args[0])
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to pause journey", flags.Verbose)
 	}
 
-	FormatOutput(journey, flags.Format, flags.Output)
+	return FormatOutput(journey, flags.Format, flags.Output)
 }
 
 // HandleJourneyResume handles journey resuming
-func HandleJourneyResume(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyResume(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
-	journeyID := args[0]
-
-	journey, err := client.CDP.ResumeJourney(ctx, journeyID)
+	journey, err := client.CDP.ResumeJourney(ctx, args[0])
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to resume journey", flags.Verbose)
 	}
 
-	FormatOutput(journey, flags.Format, flags.Output)
+	return FormatOutput(journey, flags.Format, flags.Output)
 }
 
 // HandleJourneyStatistics handles getting journey statistics
-func HandleJourneyStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
 	journeyID := args[0]
 	var from, to *time.Time
 
-	// Parse optional date parameters
 	for i := 1; i < len(args); i += 2 {
 		if i+1 >= len(args) {
 			break
@@ -221,13 +186,13 @@ func HandleJourneyStatistics(ctx context.Context, client *td.Client, args []stri
 		case "--from":
 			t, err := time.Parse(time.RFC3339, args[i+1])
 			if err != nil {
-				handleUsageError(fmt.Sprintf("Error parsing from date: %v", err), flags.Verbose)
+				return usageError(fmt.Sprintf("Error parsing from date: %v", err))
 			}
 			from = &t
 		case "--to":
 			t, err := time.Parse(time.RFC3339, args[i+1])
 			if err != nil {
-				handleUsageError(fmt.Sprintf("Error parsing to date: %v", err), flags.Verbose)
+				return usageError(fmt.Sprintf("Error parsing to date: %v", err))
 			}
 			to = &t
 		}
@@ -235,34 +200,32 @@ func HandleJourneyStatistics(ctx context.Context, client *td.Client, args []stri
 
 	stats, err := client.CDP.GetJourneyStatistics(ctx, journeyID, from, to)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to get journey statistics", flags.Verbose)
 	}
 
-	FormatOutput(stats, flags.Format, flags.Output)
+	return FormatOutput(stats, flags.Format, flags.Output)
 }
 
 // HandleJourneyCustomers handles getting journey customers
-func HandleJourneyCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
 	journeyID := args[0]
 	var limit, offset *int
 
-	// Parse optional parameters
 	for _, arg := range args[1:] {
 		if strings.HasPrefix(arg, "--limit=") {
 			val, err := strconv.Atoi(strings.TrimPrefix(arg, "--limit="))
 			if err != nil {
-				handleUsageError(fmt.Sprintf("Error parsing limit: %v", err), flags.Verbose)
+				return usageError(fmt.Sprintf("Error parsing limit: %v", err))
 			}
 			limit = &val
 		} else if strings.HasPrefix(arg, "--offset=") {
 			val, err := strconv.Atoi(strings.TrimPrefix(arg, "--offset="))
 			if err != nil {
-				handleUsageError(fmt.Sprintf("Error parsing offset: %v", err), flags.Verbose)
+				return usageError(fmt.Sprintf("Error parsing offset: %v", err))
 			}
 			offset = &val
 		}
@@ -270,35 +233,33 @@ func HandleJourneyCustomers(ctx context.Context, client *td.Client, args []strin
 
 	customers, err := client.CDP.GetJourneyCustomers(ctx, journeyID, limit, offset)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to get journey customers", flags.Verbose)
 	}
 
-	FormatOutput(customers, flags.Format, flags.Output)
+	return FormatOutput(customers, flags.Format, flags.Output)
 }
 
 // HandleJourneyStageCustomers handles getting journey stage customers
-func HandleJourneyStageCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyStageCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Error: Journey ID and Stage ID are required", flags.Verbose)
+		return usageError("Journey ID and Stage ID are required")
 	}
 
 	journeyID := args[0]
 	stageID := args[1]
 	var limit, offset *int
 
-	// Parse optional parameters
 	for _, arg := range args[2:] {
 		if strings.HasPrefix(arg, "--limit=") {
 			val, err := strconv.Atoi(strings.TrimPrefix(arg, "--limit="))
 			if err != nil {
-				handleUsageError(fmt.Sprintf("Error parsing limit: %v", err), flags.Verbose)
+				return usageError(fmt.Sprintf("Error parsing limit: %v", err))
 			}
 			limit = &val
 		} else if strings.HasPrefix(arg, "--offset=") {
 			val, err := strconv.Atoi(strings.TrimPrefix(arg, "--offset="))
 			if err != nil {
-				handleUsageError(fmt.Sprintf("Error parsing offset: %v", err), flags.Verbose)
+				return usageError(fmt.Sprintf("Error parsing offset: %v", err))
 			}
 			offset = &val
 		}
@@ -306,23 +267,21 @@ func HandleJourneyStageCustomers(ctx context.Context, client *td.Client, args []
 
 	customers, err := client.CDP.GetJourneyStageCustomers(ctx, journeyID, stageID, limit, offset)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to get journey stage customers", flags.Verbose)
 	}
 
-	FormatOutput(customers, flags.Format, flags.Output)
+	return FormatOutput(customers, flags.Format, flags.Output)
 }
 
 // HandleJourneyConversionSankey handles getting journey conversion sankey charts
-func HandleJourneyConversionSankey(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyConversionSankey(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
 	journeyID := args[0]
 	var from, to *time.Time
 
-	// Parse optional date parameters
 	for i := 1; i < len(args); i += 2 {
 		if i+1 >= len(args) {
 			break
@@ -332,13 +291,13 @@ func HandleJourneyConversionSankey(ctx context.Context, client *td.Client, args 
 		case "--from":
 			t, err := time.Parse(time.RFC3339, args[i+1])
 			if err != nil {
-				handleUsageError(fmt.Sprintf("Error parsing from date: %v", err), flags.Verbose)
+				return usageError(fmt.Sprintf("Error parsing from date: %v", err))
 			}
 			from = &t
 		case "--to":
 			t, err := time.Parse(time.RFC3339, args[i+1])
 			if err != nil {
-				handleUsageError(fmt.Sprintf("Error parsing to date: %v", err), flags.Verbose)
+				return usageError(fmt.Sprintf("Error parsing to date: %v", err))
 			}
 			to = &t
 		}
@@ -346,23 +305,21 @@ func HandleJourneyConversionSankey(ctx context.Context, client *td.Client, args 
 
 	sankey, err := client.CDP.GetJourneyConversionSankeyCharts(ctx, journeyID, from, to)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to get journey conversion sankey", flags.Verbose)
 	}
 
-	FormatOutput(sankey, flags.Format, flags.Output)
+	return FormatOutput(sankey, flags.Format, flags.Output)
 }
 
 // HandleJourneyActivationSankey handles getting journey activation sankey charts
-func HandleJourneyActivationSankey(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyActivationSankey(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
 	journeyID := args[0]
 	var from, to *time.Time
 
-	// Parse optional date parameters
 	for i := 1; i < len(args); i += 2 {
 		if i+1 >= len(args) {
 			break
@@ -372,13 +329,13 @@ func HandleJourneyActivationSankey(ctx context.Context, client *td.Client, args 
 		case "--from":
 			t, err := time.Parse(time.RFC3339, args[i+1])
 			if err != nil {
-				handleUsageError(fmt.Sprintf("Error parsing from date: %v", err), flags.Verbose)
+				return usageError(fmt.Sprintf("Error parsing from date: %v", err))
 			}
 			from = &t
 		case "--to":
 			t, err := time.Parse(time.RFC3339, args[i+1])
 			if err != nil {
-				handleUsageError(fmt.Sprintf("Error parsing to date: %v", err), flags.Verbose)
+				return usageError(fmt.Sprintf("Error parsing to date: %v", err))
 			}
 			to = &t
 		}
@@ -386,40 +343,35 @@ func HandleJourneyActivationSankey(ctx context.Context, client *td.Client, args 
 
 	sankey, err := client.CDP.GetJourneyActivationSankeyCharts(ctx, journeyID, from, to)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to get journey activation sankey", flags.Verbose)
 	}
 
-	FormatOutput(sankey, flags.Format, flags.Output)
+	return FormatOutput(sankey, flags.Format, flags.Output)
 }
 
 // HandleJourneySegmentRules handles listing journey segment rules
-func HandleJourneySegmentRules(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneySegmentRules(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Audience ID is required", flags.Verbose)
+		return usageError("Audience ID is required")
 	}
 
-	audienceID := args[0]
-
-	rules, err := client.CDP.ListJourneySegmentRules(ctx, audienceID)
+	rules, err := client.CDP.ListJourneySegmentRules(ctx, args[0])
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to list journey segment rules", flags.Verbose)
 	}
 
-	FormatOutput(rules, flags.Format, flags.Output)
+	return FormatOutput(rules, flags.Format, flags.Output)
 }
 
 // HandleJourneyBehaviors handles getting available behaviors for step
-func HandleJourneyBehaviors(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyBehaviors(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
 	journeyID := args[0]
 	var stepID *string
 
-	// Parse optional step ID parameter
 	for i := 1; i < len(args); i += 2 {
 		if i+1 >= len(args) {
 			break
@@ -432,23 +384,21 @@ func HandleJourneyBehaviors(ctx context.Context, client *td.Client, args []strin
 
 	behaviors, err := client.CDP.GetAvailableBehaviorsForStep(ctx, journeyID, stepID)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to get journey behaviors", flags.Verbose)
 	}
 
-	FormatOutput(behaviors, flags.Format, flags.Output)
+	return FormatOutput(behaviors, flags.Format, flags.Output)
 }
 
 // HandleJourneyTemplates handles getting activation templates for step
-func HandleJourneyTemplates(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleJourneyTemplates(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
 	journeyID := args[0]
 	var stepID *string
 
-	// Parse optional step ID parameter
 	for i := 1; i < len(args); i += 2 {
 		if i+1 >= len(args) {
 			break
@@ -461,102 +411,84 @@ func HandleJourneyTemplates(ctx context.Context, client *td.Client, args []strin
 
 	templates, err := client.CDP.GetActivationTemplatesForStep(ctx, journeyID, stepID)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to get journey templates", flags.Verbose)
 	}
 
-	FormatOutput(templates, flags.Format, flags.Output)
+	return FormatOutput(templates, flags.Format, flags.Output)
 }
 
-// Journey Activation handlers
-func HandleJourneyActivationList(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleJourneyActivationList lists journey activations
+func HandleJourneyActivationList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Error: Journey ID is required", flags.Verbose)
+		return usageError("Journey ID is required")
 	}
 
-	journeyID := args[0]
-
-	activations, err := client.CDP.ListJourneyActivations(ctx, journeyID)
+	activations, err := client.CDP.ListJourneyActivations(ctx, args[0])
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to list journey activations", flags.Verbose)
 	}
 
-	FormatOutput(activations, flags.Format, flags.Output)
+	return FormatOutput(activations, flags.Format, flags.Output)
 }
 
-func HandleJourneyActivationCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleJourneyActivationCreate creates a journey activation
+func HandleJourneyActivationCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Error: Journey ID and request file are required", flags.Verbose)
+		return usageError("Journey ID and request file are required")
 	}
 
-	journeyID := args[0]
-	requestFile := args[1]
-
-	// Read the request file
-	requestData, err := os.ReadFile(requestFile)
+	requestData, err := os.ReadFile(args[1])
 	if err != nil {
-		handleUsageError(fmt.Sprintf("Error reading request file: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error reading request file: %v", err))
 	}
 
-	// Parse the request
 	var request td.CDPJourneyActivationRequest
 	if err := json.Unmarshal(requestData, &request); err != nil {
-		handleUsageError(fmt.Sprintf("Error parsing request JSON: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error parsing request JSON: %v", err))
 	}
 
-	activation, err := client.CDP.CreateJourneyActivation(ctx, journeyID, &request)
+	activation, err := client.CDP.CreateJourneyActivation(ctx, args[0], &request)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to create journey activation", flags.Verbose)
 	}
 
-	FormatOutput(activation, flags.Format, flags.Output)
+	return FormatOutput(activation, flags.Format, flags.Output)
 }
 
-func HandleJourneyActivationGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleJourneyActivationGet gets a journey activation
+func HandleJourneyActivationGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Error: Journey ID and Activation Step ID are required", flags.Verbose)
+		return usageError("Journey ID and Activation Step ID are required")
 	}
 
-	journeyID := args[0]
-	activationStepID := args[1]
-
-	activation, err := client.CDP.GetJourneyActivation(ctx, journeyID, activationStepID)
+	activation, err := client.CDP.GetJourneyActivation(ctx, args[0], args[1])
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to get journey activation", flags.Verbose)
 	}
 
-	FormatOutput(activation, flags.Format, flags.Output)
+	return FormatOutput(activation, flags.Format, flags.Output)
 }
 
-func HandleJourneyActivationUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleJourneyActivationUpdate updates a journey activation
+func HandleJourneyActivationUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		handleUsageError("Error: Journey ID, Activation Step ID, and request file are required", flags.Verbose)
+		return usageError("Journey ID, Activation Step ID, and request file are required")
 	}
 
-	journeyID := args[0]
-	activationStepID := args[1]
-	requestFile := args[2]
-
-	// Read the request file
-	requestData, err := os.ReadFile(requestFile)
+	requestData, err := os.ReadFile(args[2])
 	if err != nil {
-		handleUsageError(fmt.Sprintf("Error reading request file: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error reading request file: %v", err))
 	}
 
-	// Parse the request
 	var request td.CDPJourneyActivationRequest
 	if err := json.Unmarshal(requestData, &request); err != nil {
-		handleUsageError(fmt.Sprintf("Error parsing request JSON: %v", err), flags.Verbose)
+		return usageError(fmt.Sprintf("Error parsing request JSON: %v", err))
 	}
 
-	activation, err := client.CDP.UpdateJourneyActivation(ctx, journeyID, activationStepID, &request)
+	activation, err := client.CDP.UpdateJourneyActivation(ctx, args[0], args[1], &request)
 	if err != nil {
-		HandleError(err, flags.Verbose)
-		return
+		return wrapError(err, "failed to update journey activation", flags.Verbose)
 	}
 
-	FormatOutput(activation, flags.Format, flags.Output)
+	return FormatOutput(activation, flags.Format, flags.Output)
 }

--- a/cmd/tdcli/cdp/segments.go
+++ b/cmd/tdcli/cdp/segments.go
@@ -10,25 +10,26 @@ import (
 )
 
 // HandleSegmentCreate creates a new CDP segment
-func HandleSegmentCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 4 {
-		handleUsageError("Usage: cdp segment create <audience-id> <name> <description> <query>", flags.Verbose)
+		return usageError("Usage: cdp segment create <audience-id> <name> <description> <query>")
 	}
 
 	segment, err := client.CDP.CreateSegment(ctx, args[0], args[1], args[2], args[3])
 	if err != nil {
-		handleError(err, "Failed to create segment", flags.Verbose)
+		return wrapError(err, "failed to create segment", flags.Verbose)
 	}
 
 	fmt.Printf("Segment created successfully\n")
 	fmt.Printf("ID: %s\n", segment.ID)
 	fmt.Printf("Name: %s\n", segment.Name)
+	return nil
 }
 
 // HandleSegmentList lists CDP segments
-func HandleSegmentList(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Usage: cdp segment list <audience-id>", flags.Verbose)
+		return usageError("Usage: cdp segment list <audience-id>")
 	}
 
 	opts := &td.CDPSegmentListOptions{
@@ -38,7 +39,7 @@ func HandleSegmentList(ctx context.Context, client *td.Client, args []string, fl
 
 	resp, err := client.CDP.ListSegments(ctx, args[0], opts)
 	if err != nil {
-		handleError(err, "Failed to list segments", flags.Verbose)
+		return wrapError(err, "failed to list segments", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -72,24 +73,25 @@ func HandleSegmentList(ctx context.Context, client *td.Client, args []string, fl
 	}
 
 	if err := formatAndWriteOutput(resp, flags.Format, flags.Output, "id,name,population,created_at,updated_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleSegmentGet retrieves a specific CDP segment
-func HandleSegmentGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp segment get <audience-id> <segment-id>", flags.Verbose)
+		return usageError("Usage: cdp segment get <audience-id> <segment-id>")
 	}
 
 	segment, err := client.CDP.GetSegment(ctx, args[0], args[1])
 	if err != nil {
-		handleError(err, "Failed to get segment", flags.Verbose)
+		return wrapError(err, "failed to get segment", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(segment)
+		return printJSON(segment)
 	case "csv":
 		fmt.Println("id,name,profile_count,created_at,updated_at")
 		fmt.Printf("%s,%s,%d,%s,%s\n",
@@ -107,53 +109,54 @@ func HandleSegmentGet(ctx context.Context, client *td.Client, args []string, fla
 			fmt.Printf("\nQuery:\n%s\n", segment.Query)
 		}
 	}
+	return nil
 }
 
 // HandleSegmentUpdate updates a CDP segment
-func HandleSegmentUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		handleUsageError("Usage: cdp segment update <audience-id> <segment-id> <key=value>...", flags.Verbose)
+		return usageError("Usage: cdp segment update <audience-id> <segment-id> <key=value>...")
 	}
 
 	audienceID := args[0]
 	segmentID := args[1]
 	updates := make(map[string]string)
 
-	// Parse key=value pairs
 	for _, arg := range args[2:] {
 		parts := strings.SplitN(arg, "=", 2)
 		if len(parts) != 2 {
-			handleUsageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg), flags.Verbose)
+			return usageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg))
 		}
 		updates[parts[0]] = parts[1]
 	}
 
 	segment, err := client.CDP.UpdateSegment(ctx, audienceID, segmentID, updates)
 	if err != nil {
-		handleError(err, "Failed to update segment", flags.Verbose)
+		return wrapError(err, "failed to update segment", flags.Verbose)
 	}
 
 	fmt.Printf("Segment %s updated successfully\n", segment.ID)
+	return nil
 }
 
 // HandleSegmentDelete deletes a CDP segment
-func HandleSegmentDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp segment delete <audience-id> <segment-id>", flags.Verbose)
+		return usageError("Usage: cdp segment delete <audience-id> <segment-id>")
 	}
 
-	err := client.CDP.DeleteSegment(ctx, args[0], args[1])
-	if err != nil {
-		handleError(err, "Failed to delete segment", flags.Verbose)
+	if err := client.CDP.DeleteSegment(ctx, args[0], args[1]); err != nil {
+		return wrapError(err, "failed to delete segment", flags.Verbose)
 	}
 
 	fmt.Printf("Segment %s deleted successfully\n", args[0])
+	return nil
 }
 
 // HandleSegmentFolders lists segments in a folder
-func HandleSegmentFolders(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentFolders(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp segment folders <audience-id> <folder-id>", flags.Verbose)
+		return usageError("Usage: cdp segment folders <audience-id> <folder-id>")
 	}
 
 	opts := &td.CDPSegmentListOptions{
@@ -163,7 +166,7 @@ func HandleSegmentFolders(ctx context.Context, client *td.Client, args []string,
 
 	response, err := client.CDP.ListSegmentsInFolder(ctx, args[0], args[1], opts)
 	if err != nil {
-		handleError(err, "Failed to get segments in folder", flags.Verbose)
+		return wrapError(err, "failed to get segments in folder", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -197,19 +200,20 @@ func HandleSegmentFolders(ctx context.Context, client *td.Client, args []string,
 	}
 
 	if err := formatAndWriteOutput(response.Segments, flags.Format, flags.Output, "id,name,population,created_at,updated_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleSegmentQuery executes a query for a segment
-func HandleSegmentQuery(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentQuery(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp segment query <audience-id> <query>", flags.Verbose)
+		return usageError("Usage: cdp segment query <audience-id> <query>")
 	}
 
 	resp, err := client.CDP.CreateSegmentQuery(ctx, args[0], args[1])
 	if err != nil {
-		handleError(err, "Failed to query segment", flags.Verbose)
+		return wrapError(err, "failed to query segment", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -231,34 +235,36 @@ func HandleSegmentQuery(ctx context.Context, client *td.Client, args []string, f
 	}
 
 	if err := formatAndWriteOutput(resp, flags.Format, flags.Output, "query_id,status,error,created_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleSegmentNewQuery creates a new segment query
-func HandleSegmentNewQuery(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentNewQuery(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp segment new-query <audience-id> <query>", flags.Verbose)
+		return usageError("Usage: cdp segment new-query <audience-id> <query>")
 	}
 
 	segmentQuery, err := client.CDP.CreateSegmentQuery(ctx, args[0], args[1])
 	if err != nil {
-		handleError(err, "Failed to create segment query", flags.Verbose)
+		return wrapError(err, "failed to create segment query", flags.Verbose)
 	}
 
 	fmt.Printf("Query started successfully\n")
 	fmt.Printf("Query ID: %s\n", segmentQuery.ID)
+	return nil
 }
 
 // HandleSegmentQueryStatus gets the status of a segment query
-func HandleSegmentQueryStatus(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentQueryStatus(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp segment query-status <audience-id> <query-id>", flags.Verbose)
+		return usageError("Usage: cdp segment query-status <audience-id> <query-id>")
 	}
 
 	status, err := client.CDP.GetSegmentQueryStatus(ctx, args[0], args[1])
 	if err != nil {
-		handleError(err, "Failed to get query status", flags.Verbose)
+		return wrapError(err, "failed to get query status", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -280,28 +286,29 @@ func HandleSegmentQueryStatus(ctx context.Context, client *td.Client, args []str
 	}
 
 	if err := formatAndWriteOutput(status, flags.Format, flags.Output, "query_id,status,error,created_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleSegmentKillQuery kills a running segment query
-func HandleSegmentKillQuery(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentKillQuery(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp segment kill-query <audience-id> <query-id>", flags.Verbose)
+		return usageError("Usage: cdp segment kill-query <audience-id> <query-id>")
 	}
 
-	err := client.CDP.KillSegmentQuery(ctx, args[0], args[1])
-	if err != nil {
-		handleError(err, "Failed to kill segment query", flags.Verbose)
+	if err := client.CDP.KillSegmentQuery(ctx, args[0], args[1]); err != nil {
+		return wrapError(err, "failed to kill segment query", flags.Verbose)
 	}
 
 	fmt.Printf("Query %s killed successfully\n", args[1])
+	return nil
 }
 
 // HandleSegmentCustomers gets customers in a segment
-func HandleSegmentCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentCustomers(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp segment customers <audience-id> <segment-id>", flags.Verbose)
+		return usageError("Usage: cdp segment customers <audience-id> <segment-id>")
 	}
 
 	opts := &td.CDPSegmentCustomerListOptions{
@@ -310,7 +317,7 @@ func HandleSegmentCustomers(ctx context.Context, client *td.Client, args []strin
 
 	resp, err := client.CDP.GetSegmentQueryCustomers(ctx, args[0], args[1], opts)
 	if err != nil {
-		handleError(err, "Failed to get segment customers", flags.Verbose)
+		return wrapError(err, "failed to get segment customers", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -337,24 +344,25 @@ func HandleSegmentCustomers(ctx context.Context, client *td.Client, args []strin
 	}
 
 	if err := formatAndWriteOutput(resp, flags.Format, flags.Output, "customer_id", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleSegmentStatistics gets statistics for a segment
-func HandleSegmentStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleSegmentStatistics(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp segment statistics <audience-id> <segment-id>", flags.Verbose)
+		return usageError("Usage: cdp segment statistics <audience-id> <segment-id>")
 	}
 
 	stats, err := client.CDP.GetSegmentStatistics(ctx, args[0], args[1])
 	if err != nil {
-		handleError(err, "Failed to get segment statistics", flags.Verbose)
+		return wrapError(err, "failed to get segment statistics", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(stats)
+		return printJSON(stats)
 	case "csv":
 		fmt.Println("timestamp,count,has_data")
 		for _, point := range stats {
@@ -374,12 +382,13 @@ func HandleSegmentStatistics(ctx context.Context, client *td.Client, args []stri
 			}
 		}
 	}
+	return nil
 }
 
 // HandleCreateEntitySegment creates a new entity segment
-func HandleCreateEntitySegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleCreateEntitySegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 4 {
-		handleUsageError("Usage: cdp segment create-entity <name> <description> <segment-type> <parent-folder-id>", flags.Verbose)
+		return usageError("Usage: cdp segment create-entity <name> <description> <segment-type> <parent-folder-id>")
 	}
 
 	attributes := make(map[string]interface{})
@@ -389,7 +398,7 @@ func HandleCreateEntitySegment(ctx context.Context, client *td.Client, args []st
 
 	segment, err := client.CDP.CreateEntitySegment(ctx, args[0], args[1], args[2], args[3], attributes)
 	if err != nil {
-		handleError(err, "Failed to create entity segment", flags.Verbose)
+		return wrapError(err, "failed to create entity segment", flags.Verbose)
 	}
 
 	fmt.Printf("Entity segment created successfully\n")
@@ -403,22 +412,23 @@ func HandleCreateEntitySegment(ctx context.Context, client *td.Client, args []st
 			}
 		}
 	}
+	return nil
 }
 
 // HandleGetEntitySegment retrieves an entity segment
-func HandleGetEntitySegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetEntitySegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Usage: cdp segment get-entity <segment-id>", flags.Verbose)
+		return usageError("Usage: cdp segment get-entity <segment-id>")
 	}
 
 	segment, err := client.CDP.GetEntitySegment(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get entity segment", flags.Verbose)
+		return wrapError(err, "failed to get entity segment", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(segment)
+		return printJSON(segment)
 	default:
 		if data, ok := segment.Data.(map[string]interface{}); ok {
 			if id, ok := data["id"]; ok {
@@ -443,13 +453,14 @@ func HandleGetEntitySegment(ctx context.Context, client *td.Client, args []strin
 			}
 		}
 	}
+	return nil
 }
 
 // HandleListEntitySegments lists all entity segments
-func HandleListEntitySegments(ctx context.Context, client *td.Client, flags Flags) {
+func HandleListEntitySegments(ctx context.Context, client *td.Client, flags Flags) error {
 	segments, err := client.CDP.ListEntitySegments(ctx)
 	if err != nil {
-		handleError(err, "Failed to list entity segments", flags.Verbose)
+		return wrapError(err, "failed to list entity segments", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -493,19 +504,19 @@ func HandleListEntitySegments(ctx context.Context, client *td.Client, flags Flag
 	}
 
 	if err := formatAndWriteOutput(segments, flags.Format, flags.Output, "id,name,profile_count", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleUpdateEntitySegment updates an entity segment
-func HandleUpdateEntitySegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleUpdateEntitySegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Usage: cdp segment update-entity <segment-id> [options]", flags.Verbose)
+		return usageError("Usage: cdp segment update-entity <segment-id> [options]")
 	}
 
 	updates := make(map[string]interface{})
 
-	// Parse flags for updates
 	if flags.Name != "" {
 		updates["name"] = flags.Name
 	}
@@ -518,7 +529,7 @@ func HandleUpdateEntitySegment(ctx context.Context, client *td.Client, args []st
 
 	segment, err := client.CDP.UpdateEntitySegment(ctx, args[0], updates)
 	if err != nil {
-		handleError(err, "Failed to update entity segment", flags.Verbose)
+		return wrapError(err, "failed to update entity segment", flags.Verbose)
 	}
 
 	fmt.Printf("Entity segment updated successfully\n")
@@ -527,18 +538,19 @@ func HandleUpdateEntitySegment(ctx context.Context, client *td.Client, args []st
 			fmt.Printf("ID: %v\n", id)
 		}
 	}
+	return nil
 }
 
 // HandleDeleteEntitySegment deletes an entity segment
-func HandleDeleteEntitySegment(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleDeleteEntitySegment(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Usage: cdp segment delete-entity <segment-id>", flags.Verbose)
+		return usageError("Usage: cdp segment delete-entity <segment-id>")
 	}
 
-	err := client.CDP.DeleteEntitySegment(ctx, args[0])
-	if err != nil {
-		handleError(err, "Failed to delete entity segment", flags.Verbose)
+	if err := client.CDP.DeleteEntitySegment(ctx, args[0]); err != nil {
+		return wrapError(err, "failed to delete entity segment", flags.Verbose)
 	}
 
 	fmt.Printf("Entity segment %s deleted successfully\n", args[0])
+	return nil
 }

--- a/cmd/tdcli/cdp/tokens.go
+++ b/cmd/tdcli/cdp/tokens.go
@@ -20,8 +20,7 @@ type CDPTokensListCmd struct {
 }
 
 // HandleListTokens lists CDP tokens
-func HandleListTokens(ctx context.Context, client *td.Client, cmd interface{}, flags Flags) {
-	// Type assertion to get the command with filters
+func HandleListTokens(ctx context.Context, client *td.Client, cmd interface{}, flags Flags) error {
 	var opts *td.CDPTokenListOptions
 	var audienceID string
 	switch c := cmd.(type) {
@@ -42,7 +41,7 @@ func HandleListTokens(ctx context.Context, client *td.Client, cmd interface{}, f
 
 	resp, err := client.CDP.ListTokens(ctx, audienceID, opts)
 	if err != nil {
-		handleError(err, "Failed to list tokens", flags.Verbose)
+		return wrapError(err, "failed to list tokens", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -76,24 +75,25 @@ func HandleListTokens(ctx context.Context, client *td.Client, cmd interface{}, f
 	}
 
 	if err := formatAndWriteOutput(resp, flags.Format, flags.Output, "id,name,type,status,created_at,updated_at", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapError(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
 // HandleGetEntityToken gets an entity token
-func HandleGetEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Token ID required", flags.Verbose)
+		return usageError("Token ID required")
 	}
 
 	token, err := client.CDP.GetEntityToken(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get entity token", flags.Verbose)
+		return wrapError(err, "failed to get entity token", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(token)
+		return printJSON(token)
 	case "csv":
 		fmt.Println("id,name,type,status,created_at,updated_at")
 		fmt.Printf("%s,%s,%s,%s,%s,%s\n",
@@ -120,22 +120,22 @@ func HandleGetEntityToken(ctx context.Context, client *td.Client, args []string,
 			fmt.Printf("  %s\n", metadataJSON)
 		}
 	}
+	return nil
 }
 
 // HandleUpdateEntityToken updates an entity token
-func HandleUpdateEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleUpdateEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Token ID and updates (key=value) required", flags.Verbose)
+		return usageError("Token ID and updates (key=value) required")
 	}
 
 	tokenID := args[0]
 	req := &td.CDPTokenUpdateRequest{}
 
-	// Parse key=value pairs
 	for _, arg := range args[1:] {
 		parts := strings.SplitN(arg, "=", 2)
 		if len(parts) != 2 {
-			handleUsageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg), flags.Verbose)
+			return usageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg))
 		}
 		switch parts[0] {
 		case "name":
@@ -145,52 +145,50 @@ func HandleUpdateEntityToken(ctx context.Context, client *td.Client, args []stri
 		case "status":
 			req.Status = parts[1]
 		case "scopes":
-			// Parse comma-separated scopes
 			req.Scopes = strings.Split(parts[1], ",")
 		case "metadata":
 			var metadata map[string]interface{}
-			err := json.Unmarshal([]byte(parts[1]), &metadata)
-			if err != nil {
-				handleUsageError(fmt.Sprintf("Invalid metadata JSON: %v", err), flags.Verbose)
+			if err := json.Unmarshal([]byte(parts[1]), &metadata); err != nil {
+				return usageError(fmt.Sprintf("Invalid metadata JSON: %v", err))
 			}
 			req.Metadata = metadata
 		default:
-			handleUsageError(fmt.Sprintf("Unknown field: %s", parts[0]), flags.Verbose)
+			return usageError(fmt.Sprintf("Unknown field: %s", parts[0]))
 		}
 	}
 
 	token, err := client.CDP.UpdateEntityToken(ctx, tokenID, req)
 	if err != nil {
-		handleError(err, "Failed to update entity token", flags.Verbose)
+		return wrapError(err, "failed to update entity token", flags.Verbose)
 	}
 
 	fmt.Printf("Entity token %s updated successfully\n", token.ID)
+	return nil
 }
 
 // HandleDeleteEntityToken deletes an entity token
-func HandleDeleteEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleDeleteEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("Token ID required", flags.Verbose)
+		return usageError("Token ID required")
 	}
 
-	err := client.CDP.DeleteEntityToken(ctx, args[0])
-	if err != nil {
-		handleError(err, "Failed to delete entity token", flags.Verbose)
+	if err := client.CDP.DeleteEntityToken(ctx, args[0]); err != nil {
+		return wrapError(err, "failed to delete entity token", flags.Verbose)
 	}
 
 	fmt.Printf("Entity token %s deleted successfully\n", args[0])
+	return nil
 }
 
 // HandleCreateToken creates a legacy token (audience-level)
-func HandleCreateToken(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleCreateToken(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 4 {
-		handleUsageError("Usage: cdp token create <audience-id> <key-column> <attribute-columns-json> [description]", flags.Verbose)
+		return usageError("Usage: cdp token create <audience-id> <key-column> <attribute-columns-json> [description]")
 	}
 
 	var attributeColumns []string
-	err := json.Unmarshal([]byte(args[2]), &attributeColumns)
-	if err != nil {
-		handleUsageError(fmt.Sprintf("Invalid attribute columns JSON: %v", err), flags.Verbose)
+	if err := json.Unmarshal([]byte(args[2]), &attributeColumns); err != nil {
+		return usageError(fmt.Sprintf("Invalid attribute columns JSON: %v", err))
 	}
 
 	req := &td.CDPLegacyTokenRequest{
@@ -203,28 +201,29 @@ func HandleCreateToken(ctx context.Context, client *td.Client, args []string, fl
 
 	token, err := client.CDP.CreateToken(ctx, args[0], req)
 	if err != nil {
-		handleError(err, "Failed to create token", flags.Verbose)
+		return wrapError(err, "failed to create token", flags.Verbose)
 	}
 
 	fmt.Printf("Token created successfully\n")
 	fmt.Printf("ID: %s\n", token.ID)
 	fmt.Printf("Name: %s\n", token.Name)
+	return nil
 }
 
 // HandleGetToken gets a legacy token
-func HandleGetToken(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleGetToken(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp token get <audience-id> <token-id>", flags.Verbose)
+		return usageError("Usage: cdp token get <audience-id> <token-id>")
 	}
 
 	token, err := client.CDP.GetToken(ctx, args[0], args[1])
 	if err != nil {
-		handleError(err, "Failed to get token", flags.Verbose)
+		return wrapError(err, "failed to get token", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		printJSON(token)
+		return printJSON(token)
 	case "csv":
 		fmt.Println("id,name,type,status,description,created_at,updated_at")
 		fmt.Printf("%s,%s,%s,%s,%s,%s,%s\n",
@@ -243,18 +242,18 @@ func HandleGetToken(ctx context.Context, client *td.Client, args []string, flags
 		fmt.Printf("Created: %s\n", token.CreatedAt.Format("2006-01-02 15:04:05"))
 		fmt.Printf("Updated: %s\n", token.UpdatedAt.Format("2006-01-02 15:04:05"))
 	}
+	return nil
 }
 
 // HandleUpdateToken updates a legacy token
-func HandleUpdateToken(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleUpdateToken(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		handleUsageError("Usage: cdp token update <audience-id> <token-id> <key-column> <attribute-columns-json> [description]", flags.Verbose)
+		return usageError("Usage: cdp token update <audience-id> <token-id> <key-column> <attribute-columns-json> [description]")
 	}
 
 	var attributeColumns []string
-	err := json.Unmarshal([]byte(args[3]), &attributeColumns)
-	if err != nil {
-		handleUsageError(fmt.Sprintf("Invalid attribute columns JSON: %v", err), flags.Verbose)
+	if err := json.Unmarshal([]byte(args[3]), &attributeColumns); err != nil {
+		return usageError(fmt.Sprintf("Invalid attribute columns JSON: %v", err))
 	}
 
 	req := &td.CDPLegacyTokenRequest{
@@ -267,44 +266,45 @@ func HandleUpdateToken(ctx context.Context, client *td.Client, args []string, fl
 
 	token, err := client.CDP.UpdateToken(ctx, args[0], args[1], req)
 	if err != nil {
-		handleError(err, "Failed to update token", flags.Verbose)
+		return wrapError(err, "failed to update token", flags.Verbose)
 	}
 
 	fmt.Printf("Token %s updated successfully\n", token.ID)
+	return nil
 }
 
 // HandleDeleteToken deletes a legacy token
-func HandleDeleteToken(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleDeleteToken(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		handleUsageError("Usage: cdp token delete <audience-id> <token-id>", flags.Verbose)
+		return usageError("Usage: cdp token delete <audience-id> <token-id>")
 	}
 
-	err := client.CDP.DeleteToken(ctx, args[0], args[1])
-	if err != nil {
-		handleError(err, "Failed to delete token", flags.Verbose)
+	if err := client.CDP.DeleteToken(ctx, args[0], args[1]); err != nil {
+		return wrapError(err, "failed to delete token", flags.Verbose)
 	}
 
 	fmt.Printf("Token %s deleted successfully\n", args[1])
+	return nil
 }
 
 // HandleCreateEntityToken creates an entity token
-func HandleCreateEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func HandleCreateEntityToken(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		handleUsageError("JSON string with token details required", flags.Verbose)
+		return usageError("JSON string with token details required")
 	}
 
 	var req td.CDPTokenCreateRequest
-	err := json.Unmarshal([]byte(args[0]), &req)
-	if err != nil {
-		handleUsageError(fmt.Sprintf("Invalid JSON: %v", err), flags.Verbose)
+	if err := json.Unmarshal([]byte(args[0]), &req); err != nil {
+		return usageError(fmt.Sprintf("Invalid JSON: %v", err))
 	}
 
 	token, err := client.CDP.CreateEntityToken(ctx, &req)
 	if err != nil {
-		handleError(err, "Failed to create entity token", flags.Verbose)
+		return wrapError(err, "failed to create entity token", flags.Verbose)
 	}
 
 	fmt.Printf("Entity token created successfully\n")
 	fmt.Printf("ID: %s\n", token.ID)
 	fmt.Printf("Name: %s\n", token.Name)
+	return nil
 }

--- a/cmd/tdcli/cli.go
+++ b/cmd/tdcli/cli.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
-	"github.com/mickeey2525/treasuredata-go-sdk/cmd/tdcli/cdp"
-	"github.com/mickeey2525/treasuredata-go-sdk/cmd/tdcli/workflow"
 	"github.com/mickeey2525/treasuredata-go-sdk/otel"
 )
 
@@ -87,39 +85,11 @@ type CLIContext struct {
 	OTELManager *otel.OTELManager
 }
 
-// captureHandlerErrors signals handleError to panic instead of os.Exit.
-var captureHandlerErrors = false
-
-// runHandlerWithErrorCapture wraps handler functions to capture their errors.
-func runHandlerWithErrorCapture(handlerFunc func()) (err error) {
-	originalCaptureMode := captureHandlerErrors
-	originalCDPCapture := cdp.CaptureErrors
-	originalWorkflowCapture := workflow.CaptureErrors
-	captureHandlerErrors = true
-	cdp.CaptureErrors = true
-	workflow.CaptureErrors = true
-
-	defer func() {
-		captureHandlerErrors = originalCaptureMode
-		cdp.CaptureErrors = originalCDPCapture
-		workflow.CaptureErrors = originalWorkflowCapture
-		if r := recover(); r != nil {
-			if e, ok := r.(error); ok {
-				err = e
-			} else {
-				err = fmt.Errorf("command failed: %v", r)
-			}
-		}
-	}()
-
-	handlerFunc()
-	return nil
-}
-
-// runInstrumented wraps a handler with OTEL CLI instrumentation + error capture.
-func runInstrumented(ctx *CLIContext, commandName string, args []string, handlerFunc func()) error {
+// runInstrumented wraps a handler with OTEL CLI instrumentation. Handlers
+// return errors directly; instrumentation records the result on the span.
+func runInstrumented(ctx *CLIContext, commandName string, args []string, handlerFunc func() error) error {
 	return InstrumentedRun(ctx, commandName, args, func(ctx *CLIContext) error {
-		return runHandlerWithErrorCapture(handlerFunc)
+		return handlerFunc()
 	})
 }
 

--- a/cmd/tdcli/command_cdp.go
+++ b/cmd/tdcli/command_cdp.go
@@ -38,8 +38,8 @@ type CDPSegmentsCreateCmd struct {
 
 func (c *CDPSegmentsCreateCmd) Run(ctx *CLIContext) error {
 	args := []string{c.AudienceID, c.Name}
-	return runInstrumented(ctx, "cdp.segments.create", args, func() {
-		handleCDPSegmentCreate(ctx.Context, ctx.Client, []string{c.AudienceID, c.Name, c.Description, c.Query}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.create", args, func() error {
+		return handleCDPSegmentCreate(ctx.Context, ctx.Client, []string{c.AudienceID, c.Name, c.Description, c.Query}, ctx.GlobalFlags)
 	})
 }
 
@@ -48,8 +48,8 @@ type CDPSegmentsListCmd struct {
 }
 
 func (c *CDPSegmentsListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.segments.list", []string{c.AudienceID}, func() {
-		handleCDPSegmentList(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.list", []string{c.AudienceID}, func() error {
+		return handleCDPSegmentList(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
 	})
 }
 
@@ -59,8 +59,8 @@ type CDPSegmentsGetCmd struct {
 }
 
 func (c *CDPSegmentsGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.segments.get", []string{c.AudienceID, c.SegmentID}, func() {
-		handleCDPSegmentGet(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.get", []string{c.AudienceID, c.SegmentID}, func() error {
+		return handleCDPSegmentGet(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID}, ctx.GlobalFlags)
 	})
 }
 
@@ -72,8 +72,8 @@ type CDPSegmentsUpdateCmd struct {
 
 func (c *CDPSegmentsUpdateCmd) Run(ctx *CLIContext) error {
 	args := append([]string{c.AudienceID, c.SegmentID}, c.Updates...)
-	return runInstrumented(ctx, "cdp.segments.update", args, func() {
-		handleCDPSegmentUpdate(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.update", args, func() error {
+		return handleCDPSegmentUpdate(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -83,8 +83,8 @@ type CDPSegmentsDeleteCmd struct {
 }
 
 func (c *CDPSegmentsDeleteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.segments.delete", []string{c.AudienceID, c.SegmentID}, func() {
-		handleCDPSegmentDelete(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.delete", []string{c.AudienceID, c.SegmentID}, func() error {
+		return handleCDPSegmentDelete(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID}, ctx.GlobalFlags)
 	})
 }
 
@@ -94,8 +94,8 @@ type CDPSegmentsFoldersCmd struct {
 }
 
 func (c *CDPSegmentsFoldersCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.segments.folders", []string{c.AudienceID, c.FolderID}, func() {
-		handleCDPSegmentFolders(ctx.Context, ctx.Client, []string{c.AudienceID, c.FolderID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.folders", []string{c.AudienceID, c.FolderID}, func() error {
+		return handleCDPSegmentFolders(ctx.Context, ctx.Client, []string{c.AudienceID, c.FolderID}, ctx.GlobalFlags)
 	})
 }
 
@@ -105,8 +105,8 @@ type CDPSegmentsQueryCmd struct {
 }
 
 func (c *CDPSegmentsQueryCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.segments.query", []string{c.AudienceID}, func() {
-		handleCDPSegmentQuery(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentRules}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.query", []string{c.AudienceID}, func() error {
+		return handleCDPSegmentQuery(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentRules}, ctx.GlobalFlags)
 	})
 }
 
@@ -117,8 +117,8 @@ type CDPSegmentsNewQueryCmd struct {
 }
 
 func (c *CDPSegmentsNewQueryCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.segments.new_query", []string{c.AudienceID, c.SegmentID}, func() {
-		handleCDPSegmentNewQuery(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID, c.Query}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.new_query", []string{c.AudienceID, c.SegmentID}, func() error {
+		return handleCDPSegmentNewQuery(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID, c.Query}, ctx.GlobalFlags)
 	})
 }
 
@@ -129,8 +129,8 @@ type CDPSegmentsQueryStatusCmd struct {
 }
 
 func (c *CDPSegmentsQueryStatusCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.segments.query_status", []string{c.AudienceID, c.SegmentID, c.QueryID}, func() {
-		handleCDPSegmentQueryStatus(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID, c.QueryID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.query_status", []string{c.AudienceID, c.SegmentID, c.QueryID}, func() error {
+		return handleCDPSegmentQueryStatus(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID, c.QueryID}, ctx.GlobalFlags)
 	})
 }
 
@@ -141,8 +141,8 @@ type CDPSegmentsKillQueryCmd struct {
 }
 
 func (c *CDPSegmentsKillQueryCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.segments.kill_query", []string{c.AudienceID, c.SegmentID, c.QueryID}, func() {
-		handleCDPSegmentKillQuery(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID, c.QueryID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.kill_query", []string{c.AudienceID, c.SegmentID, c.QueryID}, func() error {
+		return handleCDPSegmentKillQuery(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID, c.QueryID}, ctx.GlobalFlags)
 	})
 }
 
@@ -155,8 +155,8 @@ type CDPSegmentsCustomersCmd struct {
 }
 
 func (c *CDPSegmentsCustomersCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.segments.customers", []string{c.AudienceID, c.SegmentID}, func() {
-		handleCDPSegmentCustomers(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.customers", []string{c.AudienceID, c.SegmentID}, func() error {
+		return handleCDPSegmentCustomers(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID}, ctx.GlobalFlags)
 	})
 }
 
@@ -166,8 +166,8 @@ type CDPSegmentsStatisticsCmd struct {
 }
 
 func (c *CDPSegmentsStatisticsCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.segments.statistics", []string{c.AudienceID, c.SegmentID}, func() {
-		handleCDPSegmentStatistics(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.segments.statistics", []string{c.AudienceID, c.SegmentID}, func() error {
+		return handleCDPSegmentStatistics(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID}, ctx.GlobalFlags)
 	})
 }
 
@@ -193,16 +193,16 @@ type CDPAudiencesCreateCmd struct {
 }
 
 func (c *CDPAudiencesCreateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.audiences.create", []string{c.Name}, func() {
-		handleCDPAudienceCreate(ctx.Context, ctx.Client, []string{c.Name, c.Description, c.SegmentIDs}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.audiences.create", []string{c.Name}, func() error {
+		return handleCDPAudienceCreate(ctx.Context, ctx.Client, []string{c.Name, c.Description, c.SegmentIDs}, ctx.GlobalFlags)
 	})
 }
 
 type CDPAudiencesListCmd struct{}
 
 func (c *CDPAudiencesListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.audiences.list", []string{}, func() {
-		handleCDPAudienceList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.audiences.list", []string{}, func() error {
+		return handleCDPAudienceList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -211,8 +211,8 @@ type CDPAudiencesGetCmd struct {
 }
 
 func (c *CDPAudiencesGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.audiences.get", []string{c.AudienceID}, func() {
-		handleCDPAudienceGet(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.audiences.get", []string{c.AudienceID}, func() error {
+		return handleCDPAudienceGet(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
 	})
 }
 
@@ -221,8 +221,8 @@ type CDPAudiencesDeleteCmd struct {
 }
 
 func (c *CDPAudiencesDeleteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.audiences.delete", []string{c.AudienceID}, func() {
-		handleCDPAudienceDelete(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.audiences.delete", []string{c.AudienceID}, func() error {
+		return handleCDPAudienceDelete(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
 	})
 }
 
@@ -231,8 +231,8 @@ type CDPAudiencesBehaviorsCmd struct {
 }
 
 func (c *CDPAudiencesBehaviorsCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.audiences.behaviors", []string{c.AudienceID}, func() {
-		handleCDPAudienceBehaviors(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.audiences.behaviors", []string{c.AudienceID}, func() error {
+		return handleCDPAudienceBehaviors(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
 	})
 }
 
@@ -241,8 +241,8 @@ type CDPAudiencesRunCmd struct {
 }
 
 func (c *CDPAudiencesRunCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.audiences.run", []string{c.AudienceID}, func() {
-		handleCDPAudienceRun(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.audiences.run", []string{c.AudienceID}, func() error {
+		return handleCDPAudienceRun(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
 	})
 }
 
@@ -251,8 +251,8 @@ type CDPAudiencesExecutionsCmd struct {
 }
 
 func (c *CDPAudiencesExecutionsCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.audiences.executions", []string{c.AudienceID}, func() {
-		handleCDPAudienceExecutions(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.audiences.executions", []string{c.AudienceID}, func() error {
+		return handleCDPAudienceExecutions(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
 	})
 }
 
@@ -261,8 +261,8 @@ type CDPAudiencesStatisticsCmd struct {
 }
 
 func (c *CDPAudiencesStatisticsCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.audiences.statistics", []string{c.AudienceID}, func() {
-		handleCDPAudienceStatistics(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.audiences.statistics", []string{c.AudienceID}, func() error {
+		return handleCDPAudienceStatistics(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
 	})
 }
 
@@ -272,8 +272,8 @@ type CDPAudiencesSampleValuesCmd struct {
 }
 
 func (c *CDPAudiencesSampleValuesCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.audiences.sample_values", []string{c.AudienceID}, func() {
-		handleCDPAudienceSampleValues(ctx.Context, ctx.Client, []string{c.AudienceID, c.Column}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.audiences.sample_values", []string{c.AudienceID}, func() error {
+		return handleCDPAudienceSampleValues(ctx.Context, ctx.Client, []string{c.AudienceID, c.Column}, ctx.GlobalFlags)
 	})
 }
 
@@ -284,8 +284,8 @@ type CDPAudiencesBehaviorSamplesCmd struct {
 }
 
 func (c *CDPAudiencesBehaviorSamplesCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.audiences.behavior_samples", []string{c.AudienceID, c.BehaviorID}, func() {
-		handleCDPAudienceBehaviorSamples(ctx.Context, ctx.Client, []string{c.AudienceID, c.BehaviorID, c.Column}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.audiences.behavior_samples", []string{c.AudienceID, c.BehaviorID}, func() error {
+		return handleCDPAudienceBehaviorSamples(ctx.Context, ctx.Client, []string{c.AudienceID, c.BehaviorID, c.Column}, ctx.GlobalFlags)
 	})
 }
 
@@ -318,8 +318,8 @@ type CDPActivationsCreateCmd struct {
 }
 
 func (c *CDPActivationsCreateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.create", []string{c.SegmentID, c.Name}, func() {
-		handleCDPActivationCreate(ctx.Context, ctx.Client, []string{c.SegmentID, c.Name, c.Description, c.Configuration}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.create", []string{c.SegmentID, c.Name}, func() error {
+		return handleCDPActivationCreate(ctx.Context, ctx.Client, []string{c.SegmentID, c.Name, c.Description, c.Configuration}, ctx.GlobalFlags)
 	})
 }
 
@@ -332,12 +332,12 @@ type CDPActivationsCreateWithStructCmd struct {
 }
 
 func (c *CDPActivationsCreateWithStructCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.create_with_struct", []string{c.Name, c.SegmentID}, func() {
+	return runInstrumented(ctx, "cdp.activations.create_with_struct", []string{c.Name, c.SegmentID}, func() error {
 		args := []string{c.Name, c.Type, c.SegmentID, c.Configuration}
 		if c.Description != "" {
 			args = append(args, c.Description)
 		}
-		handleCDPActivationCreateWithStruct(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+		return handleCDPActivationCreateWithStruct(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -346,8 +346,8 @@ type CDPActivationsListCmd struct {
 }
 
 func (c *CDPActivationsListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.list", []string{}, func() {
-		handleCDPActivationListWithForce(ctx.Context, ctx.Client, ctx.GlobalFlags, c.Force)
+	return runInstrumented(ctx, "cdp.activations.list", []string{}, func() error {
+		return handleCDPActivationListWithForce(ctx.Context, ctx.Client, ctx.GlobalFlags, c.Force)
 	})
 }
 
@@ -358,8 +358,8 @@ type CDPActivationsGetCmd struct {
 }
 
 func (c *CDPActivationsGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.get", []string{c.AudienceID, c.SegmentID, c.ActivationID}, func() {
-		handleCDPActivationGet(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID, c.ActivationID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.get", []string{c.AudienceID, c.SegmentID, c.ActivationID}, func() error {
+		return handleCDPActivationGet(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID, c.ActivationID}, ctx.GlobalFlags)
 	})
 }
 
@@ -370,8 +370,8 @@ type CDPActivationsUpdateCmd struct {
 
 func (c *CDPActivationsUpdateCmd) Run(ctx *CLIContext) error {
 	args := append([]string{c.ActivationID}, c.Updates...)
-	return runInstrumented(ctx, "cdp.activations.update", args, func() {
-		handleCDPActivationUpdate(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.update", args, func() error {
+		return handleCDPActivationUpdate(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -381,8 +381,8 @@ type CDPActivationsUpdateStatusCmd struct {
 }
 
 func (c *CDPActivationsUpdateStatusCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.update_status", []string{c.ActivationID, c.Status}, func() {
-		handleCDPActivationUpdateStatus(ctx.Context, ctx.Client, []string{c.ActivationID, c.Status}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.update_status", []string{c.ActivationID, c.Status}, func() error {
+		return handleCDPActivationUpdateStatus(ctx.Context, ctx.Client, []string{c.ActivationID, c.Status}, ctx.GlobalFlags)
 	})
 }
 
@@ -391,8 +391,8 @@ type CDPActivationsDeleteCmd struct {
 }
 
 func (c *CDPActivationsDeleteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.delete", []string{c.ActivationID}, func() {
-		handleCDPActivationDelete(ctx.Context, ctx.Client, []string{c.ActivationID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.delete", []string{c.ActivationID}, func() error {
+		return handleCDPActivationDelete(ctx.Context, ctx.Client, []string{c.ActivationID}, ctx.GlobalFlags)
 	})
 }
 
@@ -401,8 +401,8 @@ type CDPActivationsExecuteCmd struct {
 }
 
 func (c *CDPActivationsExecuteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.execute", []string{c.ActivationID}, func() {
-		handleCDPExecuteActivation(ctx.Context, ctx.Client, []string{c.ActivationID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.execute", []string{c.ActivationID}, func() error {
+		return handleCDPExecuteActivation(ctx.Context, ctx.Client, []string{c.ActivationID}, ctx.GlobalFlags)
 	})
 }
 
@@ -413,8 +413,8 @@ type CDPActivationsExecutionsCmd struct {
 }
 
 func (c *CDPActivationsExecutionsCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.executions", []string{c.AudienceID, c.SegmentID, c.ActivationID}, func() {
-		handleCDPGetActivationExecutions(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID, c.ActivationID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.executions", []string{c.AudienceID, c.SegmentID, c.ActivationID}, func() error {
+		return handleCDPGetActivationExecutions(ctx.Context, ctx.Client, []string{c.AudienceID, c.SegmentID, c.ActivationID}, ctx.GlobalFlags)
 	})
 }
 
@@ -423,8 +423,8 @@ type CDPActivationsListByAudienceCmd struct {
 }
 
 func (c *CDPActivationsListByAudienceCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.list_by_audience", []string{c.AudienceID}, func() {
-		handleCDPListActivationsByAudience(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.list_by_audience", []string{c.AudienceID}, func() error {
+		return handleCDPListActivationsByAudience(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
 	})
 }
 
@@ -433,8 +433,8 @@ type CDPActivationsListBySegmentFolderCmd struct {
 }
 
 func (c *CDPActivationsListBySegmentFolderCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.list_by_segment_folder", []string{c.FolderID}, func() {
-		handleCDPListActivationsBySegmentFolder(ctx.Context, ctx.Client, []string{c.FolderID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.list_by_segment_folder", []string{c.FolderID}, func() error {
+		return handleCDPListActivationsBySegmentFolder(ctx.Context, ctx.Client, []string{c.FolderID}, ctx.GlobalFlags)
 	})
 }
 
@@ -444,8 +444,8 @@ type CDPActivationsRunSegmentCmd struct {
 }
 
 func (c *CDPActivationsRunSegmentCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.run_segment", []string{c.ActivationID, c.SegmentID}, func() {
-		handleCDPRunActivationForSegment(ctx.Context, ctx.Client, []string{c.ActivationID, c.SegmentID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.run_segment", []string{c.ActivationID, c.SegmentID}, func() error {
+		return handleCDPRunActivationForSegment(ctx.Context, ctx.Client, []string{c.ActivationID, c.SegmentID}, ctx.GlobalFlags)
 	})
 }
 
@@ -454,8 +454,8 @@ type CDPActivationsListByParentSegmentCmd struct {
 }
 
 func (c *CDPActivationsListByParentSegmentCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.list_by_parent_segment", []string{c.SegmentID}, func() {
-		handleCDPListActivationsByParentSegment(ctx.Context, ctx.Client, []string{c.SegmentID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.list_by_parent_segment", []string{c.SegmentID}, func() error {
+		return handleCDPListActivationsByParentSegment(ctx.Context, ctx.Client, []string{c.SegmentID}, ctx.GlobalFlags)
 	})
 }
 
@@ -464,8 +464,8 @@ type CDPActivationsWorkflowProjectsCmd struct {
 }
 
 func (c *CDPActivationsWorkflowProjectsCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.workflow_projects", []string{c.SegmentID}, func() {
-		handleCDPGetWorkflowProjectsForParentSegment(ctx.Context, ctx.Client, []string{c.SegmentID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.workflow_projects", []string{c.SegmentID}, func() error {
+		return handleCDPGetWorkflowProjectsForParentSegment(ctx.Context, ctx.Client, []string{c.SegmentID}, ctx.GlobalFlags)
 	})
 }
 
@@ -475,8 +475,8 @@ type CDPActivationsWorkflowsCmd struct {
 }
 
 func (c *CDPActivationsWorkflowsCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.workflows", []string{c.SegmentID, c.WorkflowProjectName}, func() {
-		handleCDPGetWorkflowsForParentSegment(ctx.Context, ctx.Client, []string{c.SegmentID, c.WorkflowProjectName}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.workflows", []string{c.SegmentID, c.WorkflowProjectName}, func() error {
+		return handleCDPGetWorkflowsForParentSegment(ctx.Context, ctx.Client, []string{c.SegmentID, c.WorkflowProjectName}, ctx.GlobalFlags)
 	})
 }
 
@@ -485,8 +485,8 @@ type CDPActivationsMatchedActivationsCmd struct {
 }
 
 func (c *CDPActivationsMatchedActivationsCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activations.matched_activations", []string{c.SegmentID}, func() {
-		handleCDPGetMatchedActivationsForParentSegment(ctx.Context, ctx.Client, []string{c.SegmentID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activations.matched_activations", []string{c.SegmentID}, func() error {
+		return handleCDPGetMatchedActivationsForParentSegment(ctx.Context, ctx.Client, []string{c.SegmentID}, ctx.GlobalFlags)
 	})
 }
 
@@ -508,8 +508,8 @@ type CDPFoldersListCmd struct {
 }
 
 func (c *CDPFoldersListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.folders.list", []string{c.AudienceID}, func() {
-		handleCDPListFolders(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.folders.list", []string{c.AudienceID}, func() error {
+		return handleCDPListFolders(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
 	})
 }
 
@@ -522,7 +522,7 @@ type CDPFoldersCreateCmd struct {
 
 func (c *CDPFoldersCreateCmd) Run(ctx *CLIContext) error {
 	args := []string{c.AudienceID, c.Name}
-	return runInstrumented(ctx, "cdp.folders.create_audience", args, func() {
+	return runInstrumented(ctx, "cdp.folders.create_audience", args, func() error {
 		realArgs := []string{c.AudienceID, c.Name}
 		if c.Description != "" {
 			realArgs = append(realArgs, c.Description)
@@ -530,7 +530,7 @@ func (c *CDPFoldersCreateCmd) Run(ctx *CLIContext) error {
 		if c.ParentID != "" {
 			realArgs = append(realArgs, c.ParentID)
 		}
-		handleCDPCreateAudienceFolder(ctx.Context, ctx.Client, realArgs, ctx.GlobalFlags)
+		return handleCDPCreateAudienceFolder(ctx.Context, ctx.Client, realArgs, ctx.GlobalFlags)
 	})
 }
 
@@ -540,8 +540,8 @@ type CDPFoldersGetCmd struct {
 }
 
 func (c *CDPFoldersGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.folders.get_audience", []string{c.AudienceID, c.FolderID}, func() {
-		handleCDPGetAudienceFolder(ctx.Context, ctx.Client, []string{c.AudienceID, c.FolderID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.folders.get_audience", []string{c.AudienceID, c.FolderID}, func() error {
+		return handleCDPGetAudienceFolder(ctx.Context, ctx.Client, []string{c.AudienceID, c.FolderID}, ctx.GlobalFlags)
 	})
 }
 
@@ -553,7 +553,7 @@ type CDPFoldersCreateEntityCmd struct {
 
 func (c *CDPFoldersCreateEntityCmd) Run(ctx *CLIContext) error {
 	args := []string{c.Name}
-	return runInstrumented(ctx, "cdp.folders.create_entity", args, func() {
+	return runInstrumented(ctx, "cdp.folders.create_entity", args, func() error {
 		realArgs := []string{c.Name}
 		if c.Description != "" {
 			realArgs = append(realArgs, c.Description)
@@ -561,7 +561,7 @@ func (c *CDPFoldersCreateEntityCmd) Run(ctx *CLIContext) error {
 		if c.ParentID != "" {
 			realArgs = append(realArgs, c.ParentID)
 		}
-		handleCDPCreateEntityFolder(ctx.Context, ctx.Client, realArgs, ctx.GlobalFlags)
+		return handleCDPCreateEntityFolder(ctx.Context, ctx.Client, realArgs, ctx.GlobalFlags)
 	})
 }
 
@@ -570,8 +570,8 @@ type CDPFoldersGetEntityCmd struct {
 }
 
 func (c *CDPFoldersGetEntityCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.folders.get_entity", []string{c.FolderID}, func() {
-		handleCDPGetEntityFolder(ctx.Context, ctx.Client, []string{c.FolderID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.folders.get_entity", []string{c.FolderID}, func() error {
+		return handleCDPGetEntityFolder(ctx.Context, ctx.Client, []string{c.FolderID}, ctx.GlobalFlags)
 	})
 }
 
@@ -584,7 +584,7 @@ type CDPFoldersUpdateEntityCmd struct {
 
 func (c *CDPFoldersUpdateEntityCmd) Run(ctx *CLIContext) error {
 	args := []string{c.FolderID}
-	return runInstrumented(ctx, "cdp.folders.update_entity", args, func() {
+	return runInstrumented(ctx, "cdp.folders.update_entity", args, func() error {
 		realArgs := []string{c.FolderID}
 		if c.Name != "" {
 			realArgs = append(realArgs, "name="+c.Name)
@@ -595,7 +595,7 @@ func (c *CDPFoldersUpdateEntityCmd) Run(ctx *CLIContext) error {
 		if c.ParentID != "" {
 			realArgs = append(realArgs, "parent_id="+c.ParentID)
 		}
-		handleCDPUpdateEntityFolder(ctx.Context, ctx.Client, realArgs, ctx.GlobalFlags)
+		return handleCDPUpdateEntityFolder(ctx.Context, ctx.Client, realArgs, ctx.GlobalFlags)
 	})
 }
 
@@ -604,8 +604,8 @@ type CDPFoldersDeleteEntityCmd struct {
 }
 
 func (c *CDPFoldersDeleteEntityCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.folders.delete_entity", []string{c.FolderID}, func() {
-		handleCDPDeleteEntityFolder(ctx.Context, ctx.Client, []string{c.FolderID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.folders.delete_entity", []string{c.FolderID}, func() error {
+		return handleCDPDeleteEntityFolder(ctx.Context, ctx.Client, []string{c.FolderID}, ctx.GlobalFlags)
 	})
 }
 
@@ -614,8 +614,8 @@ type CDPFoldersGetEntitiesCmd struct {
 }
 
 func (c *CDPFoldersGetEntitiesCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.folders.entities_by_folder", []string{c.FolderID}, func() {
-		handleCDPGetEntitiesByFolder(ctx.Context, ctx.Client, []string{c.FolderID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.folders.entities_by_folder", []string{c.FolderID}, func() error {
+		return handleCDPGetEntitiesByFolder(ctx.Context, ctx.Client, []string{c.FolderID}, ctx.GlobalFlags)
 	})
 }
 
@@ -637,8 +637,8 @@ type CDPTokensListCmd struct {
 }
 
 func (c *CDPTokensListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.tokens.list", []string{c.AudienceID}, func() {
-		handleCDPListTokens(ctx.Context, ctx.Client, c, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.tokens.list", []string{c.AudienceID}, func() error {
+		return handleCDPListTokens(ctx.Context, ctx.Client, c, ctx.GlobalFlags)
 	})
 }
 
@@ -647,8 +647,8 @@ type CDPTokensGetEntityCmd struct {
 }
 
 func (c *CDPTokensGetEntityCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.tokens.get_entity", []string{c.TokenID}, func() {
-		handleCDPGetEntityToken(ctx.Context, ctx.Client, []string{c.TokenID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.tokens.get_entity", []string{c.TokenID}, func() error {
+		return handleCDPGetEntityToken(ctx.Context, ctx.Client, []string{c.TokenID}, ctx.GlobalFlags)
 	})
 }
 
@@ -659,8 +659,8 @@ type CDPTokensUpdateEntityCmd struct {
 
 func (c *CDPTokensUpdateEntityCmd) Run(ctx *CLIContext) error {
 	args := append([]string{c.TokenID}, c.Updates...)
-	return runInstrumented(ctx, "cdp.tokens.update_entity", args, func() {
-		handleCDPUpdateEntityToken(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.tokens.update_entity", args, func() error {
+		return handleCDPUpdateEntityToken(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -669,8 +669,8 @@ type CDPTokensDeleteEntityCmd struct {
 }
 
 func (c *CDPTokensDeleteEntityCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.tokens.delete_entity", []string{c.TokenID}, func() {
-		handleCDPDeleteEntityToken(ctx.Context, ctx.Client, []string{c.TokenID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.tokens.delete_entity", []string{c.TokenID}, func() error {
+		return handleCDPDeleteEntityToken(ctx.Context, ctx.Client, []string{c.TokenID}, ctx.GlobalFlags)
 	})
 }
 
@@ -702,8 +702,8 @@ type CDPJourneysListCmd struct {
 }
 
 func (c *CDPJourneysListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.list", []string{c.FolderID}, func() {
-		handleCDPJourneyList(ctx.Context, ctx.Client, []string{c.FolderID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.list", []string{c.FolderID}, func() error {
+		return handleCDPJourneyList(ctx.Context, ctx.Client, []string{c.FolderID}, ctx.GlobalFlags)
 	})
 }
 
@@ -712,8 +712,8 @@ type CDPJourneysCreateCmd struct {
 }
 
 func (c *CDPJourneysCreateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.create", []string{}, func() {
-		handleCDPJourneyCreate(ctx.Context, ctx.Client, []string{c.RequestFile}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.create", []string{}, func() error {
+		return handleCDPJourneyCreate(ctx.Context, ctx.Client, []string{c.RequestFile}, ctx.GlobalFlags)
 	})
 }
 
@@ -722,8 +722,8 @@ type CDPJourneysGetCmd struct {
 }
 
 func (c *CDPJourneysGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.get", []string{c.JourneyID}, func() {
-		handleCDPJourneyGet(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.get", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyGet(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
 	})
 }
 
@@ -733,8 +733,8 @@ type CDPJourneysUpdateCmd struct {
 }
 
 func (c *CDPJourneysUpdateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.update", []string{c.JourneyID}, func() {
-		handleCDPJourneyUpdate(ctx.Context, ctx.Client, []string{c.JourneyID, c.RequestFile}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.update", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyUpdate(ctx.Context, ctx.Client, []string{c.JourneyID, c.RequestFile}, ctx.GlobalFlags)
 	})
 }
 
@@ -743,8 +743,8 @@ type CDPJourneysDeleteCmd struct {
 }
 
 func (c *CDPJourneysDeleteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.delete", []string{c.JourneyID}, func() {
-		handleCDPJourneyDelete(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.delete", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyDelete(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
 	})
 }
 
@@ -753,8 +753,8 @@ type CDPJourneysDetailCmd struct {
 }
 
 func (c *CDPJourneysDetailCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.detail", []string{c.JourneyID}, func() {
-		handleCDPJourneyDetail(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.detail", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyDetail(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
 	})
 }
 
@@ -763,8 +763,8 @@ type CDPJourneysDuplicateCmd struct {
 }
 
 func (c *CDPJourneysDuplicateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.duplicate", []string{}, func() {
-		handleCDPJourneyDuplicate(ctx.Context, ctx.Client, []string{c.RequestFile}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.duplicate", []string{}, func() error {
+		return handleCDPJourneyDuplicate(ctx.Context, ctx.Client, []string{c.RequestFile}, ctx.GlobalFlags)
 	})
 }
 
@@ -773,8 +773,8 @@ type CDPJourneysPauseCmd struct {
 }
 
 func (c *CDPJourneysPauseCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.pause", []string{c.JourneyID}, func() {
-		handleCDPJourneyPause(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.pause", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyPause(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
 	})
 }
 
@@ -783,8 +783,8 @@ type CDPJourneysResumeCmd struct {
 }
 
 func (c *CDPJourneysResumeCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.resume", []string{c.JourneyID}, func() {
-		handleCDPJourneyResume(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.resume", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyResume(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
 	})
 }
 
@@ -802,8 +802,8 @@ func (c *CDPJourneysStatisticsCmd) Run(ctx *CLIContext) error {
 	if c.To != "" {
 		args = append(args, "--to", c.To)
 	}
-	return runInstrumented(ctx, "cdp.journeys.statistics", []string{c.JourneyID}, func() {
-		handleCDPJourneyStatistics(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.statistics", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyStatistics(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -815,8 +815,8 @@ type CDPJourneysCustomersCmd struct {
 
 func (c *CDPJourneysCustomersCmd) Run(ctx *CLIContext) error {
 	args := []string{c.JourneyID, fmt.Sprintf("--limit=%d", c.Limit), fmt.Sprintf("--offset=%d", c.Offset)}
-	return runInstrumented(ctx, "cdp.journeys.customers", []string{c.JourneyID}, func() {
-		handleCDPJourneyCustomers(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.customers", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyCustomers(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -829,8 +829,8 @@ type CDPJourneysStageCustomersCmd struct {
 
 func (c *CDPJourneysStageCustomersCmd) Run(ctx *CLIContext) error {
 	args := []string{c.JourneyID, c.StageID, fmt.Sprintf("--limit=%d", c.Limit), fmt.Sprintf("--offset=%d", c.Offset)}
-	return runInstrumented(ctx, "cdp.journeys.stage_customers", []string{c.JourneyID, c.StageID}, func() {
-		handleCDPJourneyStageCustomers(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.stage_customers", []string{c.JourneyID, c.StageID}, func() error {
+		return handleCDPJourneyStageCustomers(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -848,8 +848,8 @@ func (c *CDPJourneysConversionSankeyCmd) Run(ctx *CLIContext) error {
 	if c.To != "" {
 		args = append(args, "--to", c.To)
 	}
-	return runInstrumented(ctx, "cdp.journeys.conversion_sankey", []string{c.JourneyID}, func() {
-		handleCDPJourneyConversionSankey(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.conversion_sankey", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyConversionSankey(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -867,8 +867,8 @@ func (c *CDPJourneysActivationSankeyCmd) Run(ctx *CLIContext) error {
 	if c.To != "" {
 		args = append(args, "--to", c.To)
 	}
-	return runInstrumented(ctx, "cdp.journeys.activation_sankey", []string{c.JourneyID}, func() {
-		handleCDPJourneyActivationSankey(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.activation_sankey", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyActivationSankey(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -877,8 +877,8 @@ type CDPJourneysSegmentRulesCmd struct {
 }
 
 func (c *CDPJourneysSegmentRulesCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.segment_rules", []string{c.AudienceID}, func() {
-		handleCDPJourneySegmentRules(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.segment_rules", []string{c.AudienceID}, func() error {
+		return handleCDPJourneySegmentRules(ctx.Context, ctx.Client, []string{c.AudienceID}, ctx.GlobalFlags)
 	})
 }
 
@@ -892,8 +892,8 @@ func (c *CDPJourneysBehaviorsCmd) Run(ctx *CLIContext) error {
 	if c.StepID != nil {
 		args = append(args, "--step-id", *c.StepID)
 	}
-	return runInstrumented(ctx, "cdp.journeys.behaviors", []string{c.JourneyID}, func() {
-		handleCDPJourneyBehaviors(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.behaviors", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyBehaviors(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -907,8 +907,8 @@ func (c *CDPJourneysTemplatesCmd) Run(ctx *CLIContext) error {
 	if c.StepID != nil {
 		args = append(args, "--step-id", *c.StepID)
 	}
-	return runInstrumented(ctx, "cdp.journeys.templates", []string{c.JourneyID}, func() {
-		handleCDPJourneyTemplates(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.templates", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyTemplates(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -924,8 +924,8 @@ type CDPJourneyActivationsListCmd struct {
 }
 
 func (c *CDPJourneyActivationsListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.activations.list", []string{c.JourneyID}, func() {
-		handleCDPJourneyActivationList(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.activations.list", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyActivationList(ctx.Context, ctx.Client, []string{c.JourneyID}, ctx.GlobalFlags)
 	})
 }
 
@@ -935,8 +935,8 @@ type CDPJourneyActivationsCreateCmd struct {
 }
 
 func (c *CDPJourneyActivationsCreateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.activations.create", []string{c.JourneyID}, func() {
-		handleCDPJourneyActivationCreate(ctx.Context, ctx.Client, []string{c.JourneyID, c.RequestFile}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.activations.create", []string{c.JourneyID}, func() error {
+		return handleCDPJourneyActivationCreate(ctx.Context, ctx.Client, []string{c.JourneyID, c.RequestFile}, ctx.GlobalFlags)
 	})
 }
 
@@ -946,8 +946,8 @@ type CDPJourneyActivationsGetCmd struct {
 }
 
 func (c *CDPJourneyActivationsGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.activations.get", []string{c.JourneyID, c.ActivationStepID}, func() {
-		handleCDPJourneyActivationGet(ctx.Context, ctx.Client, []string{c.JourneyID, c.ActivationStepID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.activations.get", []string{c.JourneyID, c.ActivationStepID}, func() error {
+		return handleCDPJourneyActivationGet(ctx.Context, ctx.Client, []string{c.JourneyID, c.ActivationStepID}, ctx.GlobalFlags)
 	})
 }
 
@@ -958,8 +958,8 @@ type CDPJourneyActivationsUpdateCmd struct {
 }
 
 func (c *CDPJourneyActivationsUpdateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.journeys.activations.update", []string{c.JourneyID, c.ActivationStepID}, func() {
-		handleCDPJourneyActivationUpdate(ctx.Context, ctx.Client, []string{c.JourneyID, c.ActivationStepID, c.RequestFile}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.journeys.activations.update", []string{c.JourneyID, c.ActivationStepID}, func() error {
+		return handleCDPJourneyActivationUpdate(ctx.Context, ctx.Client, []string{c.JourneyID, c.ActivationStepID, c.RequestFile}, ctx.GlobalFlags)
 	})
 }
 
@@ -978,8 +978,8 @@ type CDPActivationTemplatesListCmd struct {
 }
 
 func (c *CDPActivationTemplatesListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activation_templates.list", []string{c.ParentSegmentID}, func() {
-		handleCDPActivationTemplateList(ctx.Context, ctx.Client, []string{c.ParentSegmentID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activation_templates.list", []string{c.ParentSegmentID}, func() error {
+		return handleCDPActivationTemplateList(ctx.Context, ctx.Client, []string{c.ParentSegmentID}, ctx.GlobalFlags)
 	})
 }
 
@@ -988,8 +988,8 @@ type CDPActivationTemplatesCreateCmd struct {
 }
 
 func (c *CDPActivationTemplatesCreateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activation_templates.create", []string{}, func() {
-		handleCDPActivationTemplateCreate(ctx.Context, ctx.Client, []string{c.RequestFile}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activation_templates.create", []string{}, func() error {
+		return handleCDPActivationTemplateCreate(ctx.Context, ctx.Client, []string{c.RequestFile}, ctx.GlobalFlags)
 	})
 }
 
@@ -998,8 +998,8 @@ type CDPActivationTemplatesGetCmd struct {
 }
 
 func (c *CDPActivationTemplatesGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activation_templates.get", []string{c.TemplateID}, func() {
-		handleCDPActivationTemplateGet(ctx.Context, ctx.Client, []string{c.TemplateID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activation_templates.get", []string{c.TemplateID}, func() error {
+		return handleCDPActivationTemplateGet(ctx.Context, ctx.Client, []string{c.TemplateID}, ctx.GlobalFlags)
 	})
 }
 
@@ -1009,8 +1009,8 @@ type CDPActivationTemplatesUpdateCmd struct {
 }
 
 func (c *CDPActivationTemplatesUpdateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activation_templates.update", []string{c.TemplateID}, func() {
-		handleCDPActivationTemplateUpdate(ctx.Context, ctx.Client, []string{c.TemplateID, c.RequestFile}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activation_templates.update", []string{c.TemplateID}, func() error {
+		return handleCDPActivationTemplateUpdate(ctx.Context, ctx.Client, []string{c.TemplateID, c.RequestFile}, ctx.GlobalFlags)
 	})
 }
 
@@ -1019,7 +1019,7 @@ type CDPActivationTemplatesDeleteCmd struct {
 }
 
 func (c *CDPActivationTemplatesDeleteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "cdp.activation_templates.delete", []string{c.TemplateID}, func() {
-		handleCDPActivationTemplateDelete(ctx.Context, ctx.Client, []string{c.TemplateID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "cdp.activation_templates.delete", []string{c.TemplateID}, func() error {
+		return handleCDPActivationTemplateDelete(ctx.Context, ctx.Client, []string{c.TemplateID}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_databases.go
+++ b/cmd/tdcli/command_databases.go
@@ -11,8 +11,8 @@ type DatabasesCmd struct {
 type DatabasesListCmd struct{}
 
 func (d *DatabasesListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "databases.list", []string{}, func() {
-		handleDatabaseList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+	return runInstrumented(ctx, "databases.list", []string{}, func() error {
+		return handleDatabaseList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -21,8 +21,8 @@ type DatabasesGetCmd struct {
 }
 
 func (d *DatabasesGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "databases.get", []string{d.Name}, func() {
-		handleDatabaseGet(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "databases.get", []string{d.Name}, func() error {
+		return handleDatabaseGet(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
 	})
 }
 
@@ -31,8 +31,8 @@ type DatabasesCreateCmd struct {
 }
 
 func (d *DatabasesCreateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "databases.create", []string{d.Name}, func() {
-		handleDatabaseCreate(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "databases.create", []string{d.Name}, func() error {
+		return handleDatabaseCreate(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
 	})
 }
 
@@ -41,8 +41,8 @@ type DatabasesDeleteCmd struct {
 }
 
 func (d *DatabasesDeleteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "databases.delete", []string{d.Name}, func() {
-		handleDatabaseDelete(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "databases.delete", []string{d.Name}, func() error {
+		return handleDatabaseDelete(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
 	})
 }
 
@@ -51,7 +51,7 @@ type DatabasesUpdateCmd struct {
 }
 
 func (d *DatabasesUpdateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "databases.update", []string{d.Name}, func() {
-		handleDatabaseUpdate(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "databases.update", []string{d.Name}, func() error {
+		return handleDatabaseUpdate(ctx.Context, ctx.Client, []string{d.Name}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_import.go
+++ b/cmd/tdcli/command_import.go
@@ -16,8 +16,8 @@ type ImportCmd struct {
 type ImportListCmd struct{}
 
 func (i *ImportListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "bulk-import.list", []string{}, func() {
-		handleBulkImportList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+	return runInstrumented(ctx, "bulk-import.list", []string{}, func() error {
+		return handleBulkImportList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -26,8 +26,8 @@ type ImportGetCmd struct {
 }
 
 func (i *ImportGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "bulk-import.get", []string{i.Session}, func() {
-		handleBulkImportGet(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "bulk-import.get", []string{i.Session}, func() error {
+		return handleBulkImportGet(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
 
@@ -38,8 +38,8 @@ type ImportCreateCmd struct {
 }
 
 func (i *ImportCreateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "bulk-import.create", []string{i.Session, i.Database, i.Table}, func() {
-		handleBulkImportCreate(ctx.Context, ctx.Client, []string{i.Session, i.Database, i.Table}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "bulk-import.create", []string{i.Session, i.Database, i.Table}, func() error {
+		return handleBulkImportCreate(ctx.Context, ctx.Client, []string{i.Session, i.Database, i.Table}, ctx.GlobalFlags)
 	})
 }
 
@@ -48,8 +48,8 @@ type ImportDeleteCmd struct {
 }
 
 func (i *ImportDeleteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "bulk-import.delete", []string{i.Session}, func() {
-		handleBulkImportDelete(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "bulk-import.delete", []string{i.Session}, func() error {
+		return handleBulkImportDelete(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
 
@@ -60,8 +60,8 @@ type ImportUploadCmd struct {
 }
 
 func (i *ImportUploadCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "bulk-import.upload", []string{i.Session, i.PartName, i.FilePath}, func() {
-		handleBulkImportUpload(ctx.Context, ctx.Client, []string{i.Session, i.PartName, i.FilePath}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "bulk-import.upload", []string{i.Session, i.PartName, i.FilePath}, func() error {
+		return handleBulkImportUpload(ctx.Context, ctx.Client, []string{i.Session, i.PartName, i.FilePath}, ctx.GlobalFlags)
 	})
 }
 
@@ -70,8 +70,8 @@ type ImportCommitCmd struct {
 }
 
 func (i *ImportCommitCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "bulk-import.commit", []string{i.Session}, func() {
-		handleBulkImportCommit(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "bulk-import.commit", []string{i.Session}, func() error {
+		return handleBulkImportCommit(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
 
@@ -80,8 +80,8 @@ type ImportPerformCmd struct {
 }
 
 func (i *ImportPerformCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "bulk-import.perform", []string{i.Session}, func() {
-		handleBulkImportPerform(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "bulk-import.perform", []string{i.Session}, func() error {
+		return handleBulkImportPerform(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
 
@@ -90,8 +90,8 @@ type ImportFreezeCmd struct {
 }
 
 func (i *ImportFreezeCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "bulk-import.freeze", []string{i.Session}, func() {
-		handleBulkImportFreeze(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "bulk-import.freeze", []string{i.Session}, func() error {
+		return handleBulkImportFreeze(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
 
@@ -100,8 +100,8 @@ type ImportUnfreezeCmd struct {
 }
 
 func (i *ImportUnfreezeCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "bulk-import.unfreeze", []string{i.Session}, func() {
-		handleBulkImportUnfreeze(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "bulk-import.unfreeze", []string{i.Session}, func() error {
+		return handleBulkImportUnfreeze(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }
 
@@ -110,7 +110,7 @@ type ImportPartsCmd struct {
 }
 
 func (i *ImportPartsCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "bulk-import.parts", []string{i.Session}, func() {
-		handleBulkImportParts(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "bulk-import.parts", []string{i.Session}, func() error {
+		return handleBulkImportParts(ctx.Context, ctx.Client, []string{i.Session}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_jobs.go
+++ b/cmd/tdcli/command_jobs.go
@@ -11,9 +11,9 @@ type JobsListCmd struct {
 }
 
 func (j *JobsListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "jobs.list", []string{}, func() {
+	return runInstrumented(ctx, "jobs.list", []string{}, func() error {
 		ctx.GlobalFlags.Status = j.Status
-		handleJobList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+		return handleJobList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -22,8 +22,8 @@ type JobsGetCmd struct {
 }
 
 func (j *JobsGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "jobs.get", []string{j.JobID}, func() {
-		handleJobGet(ctx.Context, ctx.Client, []string{j.JobID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "jobs.get", []string{j.JobID}, func() error {
+		return handleJobGet(ctx.Context, ctx.Client, []string{j.JobID}, ctx.GlobalFlags)
 	})
 }
 
@@ -32,7 +32,7 @@ type JobsCancelCmd struct {
 }
 
 func (j *JobsCancelCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "jobs.cancel", []string{j.JobID}, func() {
-		handleJobCancel(ctx.Context, ctx.Client, []string{j.JobID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "jobs.cancel", []string{j.JobID}, func() error {
+		return handleJobCancel(ctx.Context, ctx.Client, []string{j.JobID}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_llm.go
+++ b/cmd/tdcli/command_llm.go
@@ -16,8 +16,8 @@ type LLMActionsCmd struct {
 type LLMActionsListCmd struct{}
 
 func (l *LLMActionsListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "llm.actions.list", []string{}, func() {
-		handleLLMActionList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+	return runInstrumented(ctx, "llm.actions.list", []string{}, func() error {
+		return handleLLMActionList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -26,8 +26,8 @@ type LLMActionsGetCmd struct {
 }
 
 func (l *LLMActionsGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "llm.actions.get", []string{l.ActionID}, func() {
-		handleLLMActionGet(ctx.Context, ctx.Client, []string{l.ActionID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "llm.actions.get", []string{l.ActionID}, func() error {
+		return handleLLMActionGet(ctx.Context, ctx.Client, []string{l.ActionID}, ctx.GlobalFlags)
 	})
 }
 
@@ -37,8 +37,8 @@ type LLMActionsExecuteCmd struct {
 }
 
 func (l *LLMActionsExecuteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "llm.actions.execute", []string{l.ActionID}, func() {
-		handleLLMActionExecute(ctx.Context, ctx.Client, []string{l.ActionID, l.Input}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "llm.actions.execute", []string{l.ActionID}, func() error {
+		return handleLLMActionExecute(ctx.Context, ctx.Client, []string{l.ActionID, l.Input}, ctx.GlobalFlags)
 	})
 }
 
@@ -49,8 +49,8 @@ type LLMIntegrationsCmd struct {
 type LLMIntegrationsListCmd struct{}
 
 func (l *LLMIntegrationsListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "llm.integrations.list", []string{}, func() {
-		handleLLMIntegrationList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+	return runInstrumented(ctx, "llm.integrations.list", []string{}, func() error {
+		return handleLLMIntegrationList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -61,8 +61,8 @@ type LLMPromptsCmd struct {
 type LLMPromptsListCmd struct{}
 
 func (l *LLMPromptsListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "llm.prompts.list", []string{}, func() {
-		handleLLMPromptList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+	return runInstrumented(ctx, "llm.prompts.list", []string{}, func() error {
+		return handleLLMPromptList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -74,8 +74,8 @@ type LLMProjectsCmd struct {
 type LLMProjectsListCmd struct{}
 
 func (l *LLMProjectsListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "llm.projects.list", []string{}, func() {
-		handleLLMProjectList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+	return runInstrumented(ctx, "llm.projects.list", []string{}, func() error {
+		return handleLLMProjectList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -84,7 +84,7 @@ type LLMProjectsGetCmd struct {
 }
 
 func (l *LLMProjectsGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "llm.projects.get", []string{l.ProjectID}, func() {
-		handleLLMProjectGet(ctx.Context, ctx.Client, []string{l.ProjectID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "llm.projects.get", []string{l.ProjectID}, func() error {
+		return handleLLMProjectGet(ctx.Context, ctx.Client, []string{l.ProjectID}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_permissions.go
+++ b/cmd/tdcli/command_permissions.go
@@ -18,8 +18,8 @@ type PermsPoliciesCmd struct {
 type PermsPoliciesListCmd struct{}
 
 func (p *PermsPoliciesListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "permissions.policies.list", []string{}, func() {
-		handlePolicyList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+	return runInstrumented(ctx, "permissions.policies.list", []string{}, func() error {
+		return handlePolicyList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -28,8 +28,8 @@ type PermsPoliciesGetCmd struct {
 }
 
 func (p *PermsPoliciesGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "permissions.policies.get", []string{fmt.Sprintf("%d", p.PolicyID)}, func() {
-		handlePolicyGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", p.PolicyID)}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "permissions.policies.get", []string{fmt.Sprintf("%d", p.PolicyID)}, func() error {
+		return handlePolicyGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", p.PolicyID)}, ctx.GlobalFlags)
 	})
 }
 
@@ -39,12 +39,12 @@ type PermsPoliciesCreateCmd struct {
 }
 
 func (p *PermsPoliciesCreateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "permissions.policies.create", []string{p.Name}, func() {
+	return runInstrumented(ctx, "permissions.policies.create", []string{p.Name}, func() error {
 		args := []string{p.Name}
 		if p.Description != "" {
 			args = append(args, p.Description)
 		}
-		handlePolicyCreate(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+		return handlePolicyCreate(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -53,8 +53,8 @@ type PermsPoliciesDeleteCmd struct {
 }
 
 func (p *PermsPoliciesDeleteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "permissions.policies.delete", []string{fmt.Sprintf("%d", p.PolicyID)}, func() {
-		handlePolicyDelete(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", p.PolicyID)}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "permissions.policies.delete", []string{fmt.Sprintf("%d", p.PolicyID)}, func() error {
+		return handlePolicyDelete(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", p.PolicyID)}, ctx.GlobalFlags)
 	})
 }
 
@@ -68,8 +68,8 @@ type PermsGroupsCmd struct {
 type PermsGroupsListCmd struct{}
 
 func (p *PermsGroupsListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "permissions.groups.list", []string{}, func() {
-		handlePolicyGroupList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+	return runInstrumented(ctx, "permissions.groups.list", []string{}, func() error {
+		return handlePolicyGroupList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -78,8 +78,8 @@ type PermsGroupsGetCmd struct {
 }
 
 func (p *PermsGroupsGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "permissions.groups.get", []string{p.GroupID}, func() {
-		handlePolicyGroupGet(ctx.Context, ctx.Client, []string{p.GroupID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "permissions.groups.get", []string{p.GroupID}, func() error {
+		return handlePolicyGroupGet(ctx.Context, ctx.Client, []string{p.GroupID}, ctx.GlobalFlags)
 	})
 }
 
@@ -88,8 +88,8 @@ type PermsGroupsCreateCmd struct {
 }
 
 func (p *PermsGroupsCreateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "permissions.groups.create", []string{p.Name}, func() {
-		handlePolicyGroupCreate(ctx.Context, ctx.Client, []string{p.Name}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "permissions.groups.create", []string{p.Name}, func() error {
+		return handlePolicyGroupCreate(ctx.Context, ctx.Client, []string{p.Name}, ctx.GlobalFlags)
 	})
 }
 
@@ -98,8 +98,8 @@ type PermsGroupsDeleteCmd struct {
 }
 
 func (p *PermsGroupsDeleteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "permissions.groups.delete", []string{p.GroupID}, func() {
-		handlePolicyGroupDelete(ctx.Context, ctx.Client, []string{p.GroupID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "permissions.groups.delete", []string{p.GroupID}, func() error {
+		return handlePolicyGroupDelete(ctx.Context, ctx.Client, []string{p.GroupID}, ctx.GlobalFlags)
 	})
 }
 
@@ -113,9 +113,9 @@ type PermsUsersListCmd struct {
 }
 
 func (p *PermsUsersListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "permissions.users.list", []string{}, func() {
+	return runInstrumented(ctx, "permissions.users.list", []string{}, func() error {
 		ctx.GlobalFlags.WithDetails = p.WithDetails
-		handleAccessControlUserList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+		return handleAccessControlUserList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -124,7 +124,7 @@ type PermsUsersGetCmd struct {
 }
 
 func (p *PermsUsersGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "permissions.users.get", []string{fmt.Sprintf("%d", p.UserID)}, func() {
-		handleAccessControlUserGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", p.UserID)}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "permissions.users.get", []string{fmt.Sprintf("%d", p.UserID)}, func() error {
+		return handleAccessControlUserGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", p.UserID)}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_personalization.go
+++ b/cmd/tdcli/command_personalization.go
@@ -12,7 +12,7 @@ type PersonalizationSendCmd struct {
 }
 
 func (p *PersonalizationSendCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "personalization.send", []string{p.Database, p.Table}, func() {
-		handlePersonalizationSend(ctx.Context, ctx.Client, []string{p.Database, p.Table, p.Data, p.Token}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "personalization.send", []string{p.Database, p.Table}, func() error {
+		return handlePersonalizationSend(ctx.Context, ctx.Client, []string{p.Database, p.Table, p.Data, p.Token}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_postback.go
+++ b/cmd/tdcli/command_postback.go
@@ -11,7 +11,7 @@ type PostbackSendCmd struct {
 }
 
 func (p *PostbackSendCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "postback.send", []string{p.Database, p.Table}, func() {
-		handlePostbackSend(ctx.Context, ctx.Client, []string{p.Database, p.Table, p.Data}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "postback.send", []string{p.Database, p.Table}, func() error {
+		return handlePostbackSend(ctx.Context, ctx.Client, []string{p.Database, p.Table, p.Data}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_queries.go
+++ b/cmd/tdcli/command_queries.go
@@ -18,11 +18,11 @@ type QuerySubmitCmd struct {
 }
 
 func (q *QuerySubmitCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "queries.submit", []string{q.Query}, func() {
+	return runInstrumented(ctx, "queries.submit", []string{q.Query}, func() error {
 		ctx.GlobalFlags.Database = q.Database
 		ctx.GlobalFlags.Priority = q.Priority
 		ctx.GlobalFlags.Engine = q.Engine
-		handleQuerySubmit(ctx.Context, ctx.Client, []string{q.Query}, ctx.GlobalFlags)
+		return handleQuerySubmit(ctx.Context, ctx.Client, []string{q.Query}, ctx.GlobalFlags)
 	})
 }
 
@@ -31,8 +31,8 @@ type QueryStatusCmd struct {
 }
 
 func (q *QueryStatusCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "queries.status", []string{q.JobID}, func() {
-		handleQueryStatus(ctx.Context, ctx.Client, []string{q.JobID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "queries.status", []string{q.JobID}, func() error {
+		return handleQueryStatus(ctx.Context, ctx.Client, []string{q.JobID}, ctx.GlobalFlags)
 	})
 }
 
@@ -42,9 +42,9 @@ type QueryResultCmd struct {
 }
 
 func (q *QueryResultCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "queries.result", []string{q.JobID}, func() {
+	return runInstrumented(ctx, "queries.result", []string{q.JobID}, func() error {
 		ctx.GlobalFlags.Limit = q.Limit
-		handleQueryResult(ctx.Context, ctx.Client, []string{q.JobID}, ctx.GlobalFlags)
+		return handleQueryResult(ctx.Context, ctx.Client, []string{q.JobID}, ctx.GlobalFlags)
 	})
 }
 
@@ -53,9 +53,9 @@ type QueryListCmd struct {
 }
 
 func (q *QueryListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "queries.list", []string{}, func() {
+	return runInstrumented(ctx, "queries.list", []string{}, func() error {
 		ctx.GlobalFlags.Status = q.Status
-		handleQueryList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+		return handleQueryList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -64,7 +64,7 @@ type QueryCancelCmd struct {
 }
 
 func (q *QueryCancelCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "queries.cancel", []string{q.JobID}, func() {
-		handleQueryCancel(ctx.Context, ctx.Client, []string{q.JobID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "queries.cancel", []string{q.JobID}, func() error {
+		return handleQueryCancel(ctx.Context, ctx.Client, []string{q.JobID}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_results.go
+++ b/cmd/tdcli/command_results.go
@@ -10,8 +10,8 @@ type ResultsGetCmd struct {
 }
 
 func (r *ResultsGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "results.get", []string{r.JobID}, func() {
+	return runInstrumented(ctx, "results.get", []string{r.JobID}, func() error {
 		ctx.GlobalFlags.Limit = r.Limit
-		handleResultGet(ctx.Context, ctx.Client, []string{r.JobID}, ctx.GlobalFlags)
+		return handleResultGet(ctx.Context, ctx.Client, []string{r.JobID}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_stream.go
+++ b/cmd/tdcli/command_stream.go
@@ -12,7 +12,7 @@ type StreamImportCmd struct {
 }
 
 func (s *StreamImportCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "stream.import", []string{s.Database, s.Table, s.FilePath}, func() {
-		handleStreamImport(ctx.Context, ctx.Client, []string{s.Database, s.Table, s.FilePath, s.UniqueID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "stream.import", []string{s.Database, s.Table, s.FilePath}, func() error {
+		return handleStreamImport(ctx.Context, ctx.Client, []string{s.Database, s.Table, s.FilePath, s.UniqueID}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_tables.go
+++ b/cmd/tdcli/command_tables.go
@@ -14,8 +14,8 @@ type TablesListCmd struct {
 }
 
 func (t *TablesListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "tables.list", []string{t.Database}, func() {
-		handleTableList(ctx.Context, ctx.Client, []string{t.Database}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "tables.list", []string{t.Database}, func() error {
+		return handleTableList(ctx.Context, ctx.Client, []string{t.Database}, ctx.GlobalFlags)
 	})
 }
 
@@ -25,8 +25,8 @@ type TablesGetCmd struct {
 }
 
 func (t *TablesGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "tables.get", []string{t.Database, t.Table}, func() {
-		handleTableGet(ctx.Context, ctx.Client, []string{t.Database, t.Table}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "tables.get", []string{t.Database, t.Table}, func() error {
+		return handleTableGet(ctx.Context, ctx.Client, []string{t.Database, t.Table}, ctx.GlobalFlags)
 	})
 }
 
@@ -36,8 +36,8 @@ type TablesCreateCmd struct {
 }
 
 func (t *TablesCreateCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "tables.create", []string{t.Database, t.Table}, func() {
-		handleTableCreate(ctx.Context, ctx.Client, []string{t.Database, t.Table}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "tables.create", []string{t.Database, t.Table}, func() error {
+		return handleTableCreate(ctx.Context, ctx.Client, []string{t.Database, t.Table}, ctx.GlobalFlags)
 	})
 }
 
@@ -47,8 +47,8 @@ type TablesDeleteCmd struct {
 }
 
 func (t *TablesDeleteCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "tables.delete", []string{t.Database, t.Table}, func() {
-		handleTableDelete(ctx.Context, ctx.Client, []string{t.Database, t.Table}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "tables.delete", []string{t.Database, t.Table}, func() error {
+		return handleTableDelete(ctx.Context, ctx.Client, []string{t.Database, t.Table}, ctx.GlobalFlags)
 	})
 }
 
@@ -59,8 +59,8 @@ type TablesSwapCmd struct {
 }
 
 func (t *TablesSwapCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "tables.swap", []string{t.Database, t.Table1, t.Table2}, func() {
-		handleTableSwap(ctx.Context, ctx.Client, []string{t.Database, t.Table1, t.Table2}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "tables.swap", []string{t.Database, t.Table1, t.Table2}, func() error {
+		return handleTableSwap(ctx.Context, ctx.Client, []string{t.Database, t.Table1, t.Table2}, ctx.GlobalFlags)
 	})
 }
 
@@ -71,7 +71,7 @@ type TablesRenameCmd struct {
 }
 
 func (t *TablesRenameCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "tables.rename", []string{t.Database, t.OldName, t.NewName}, func() {
-		handleTableRename(ctx.Context, ctx.Client, []string{t.Database, t.OldName, t.NewName}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "tables.rename", []string{t.Database, t.OldName, t.NewName}, func() error {
+		return handleTableRename(ctx.Context, ctx.Client, []string{t.Database, t.OldName, t.NewName}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_trino.go
+++ b/cmd/tdcli/command_trino.go
@@ -20,12 +20,11 @@ type TrinoQueryCmd struct {
 func (t *TrinoQueryCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
 	ctx.GlobalFlags.Limit = t.Limit
-	return runInstrumented(ctx, "trino.query", []string{t.Query}, func() {
+	return runInstrumented(ctx, "trino.query", []string{t.Query}, func() error {
 		if t.PageSize > 0 {
-			handleTrinoQueryWithPagination(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags, t.PageSize)
-		} else {
-			handleTrinoQuery(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags)
+			return handleTrinoQueryWithPagination(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags, t.PageSize)
 		}
+		return handleTrinoQuery(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags)
 	})
 }
 
@@ -35,8 +34,8 @@ type TrinoInteractiveCmd struct {
 
 func (t *TrinoInteractiveCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
-	return runInstrumented(ctx, "trino.interactive", []string{}, func() {
-		handleTrinoInteractive(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "trino.interactive", []string{}, func() error {
+		return handleTrinoInteractive(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
 	})
 }
 
@@ -46,8 +45,8 @@ type TrinoTestCmd struct {
 
 func (t *TrinoTestCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
-	return runInstrumented(ctx, "trino.test", []string{}, func() {
-		handleTrinoTest(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "trino.test", []string{}, func() error {
+		return handleTrinoTest(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
 	})
 }
 
@@ -58,8 +57,8 @@ type TrinoDescribeCmd struct {
 
 func (t *TrinoDescribeCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
-	return runInstrumented(ctx, "trino.describe", []string{t.Table}, func() {
-		handleTrinoDescribe(ctx.Context, ctx.Client, []string{t.Table}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "trino.describe", []string{t.Table}, func() error {
+		return handleTrinoDescribe(ctx.Context, ctx.Client, []string{t.Table}, ctx.GlobalFlags)
 	})
 }
 
@@ -75,8 +74,8 @@ func (t *TrinoShowCmd) Run(ctx *CLIContext) error {
 	if t.Table != "" {
 		args = append(args, t.Table)
 	}
-	return runInstrumented(ctx, "trino.show", args, func() {
-		handleTrinoShow(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
+	return runInstrumented(ctx, "trino.show", args, func() error {
+		return handleTrinoShow(ctx.Context, ctx.Client, args, ctx.GlobalFlags)
 	})
 }
 
@@ -87,8 +86,8 @@ type TrinoExplainCmd struct {
 
 func (t *TrinoExplainCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
-	return runInstrumented(ctx, "trino.explain", []string{t.Query}, func() {
-		handleTrinoExplain(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "trino.explain", []string{t.Query}, func() error {
+		return handleTrinoExplain(ctx.Context, ctx.Client, []string{t.Query}, ctx.GlobalFlags)
 	})
 }
 
@@ -98,7 +97,7 @@ type TrinoVersionCmd struct {
 
 func (t *TrinoVersionCmd) Run(ctx *CLIContext) error {
 	ctx.GlobalFlags.Database = t.Database
-	return runInstrumented(ctx, "trino.version", []string{}, func() {
-		handleTrinoVersion(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "trino.version", []string{}, func() error {
+		return handleTrinoVersion(ctx.Context, ctx.Client, []string{}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_users.go
+++ b/cmd/tdcli/command_users.go
@@ -8,8 +8,8 @@ type UsersCmd struct {
 type UsersListCmd struct{}
 
 func (u *UsersListCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "users.list", []string{}, func() {
-		handleUserList(ctx.Context, ctx.Client, ctx.GlobalFlags)
+	return runInstrumented(ctx, "users.list", []string{}, func() error {
+		return handleUserList(ctx.Context, ctx.Client, ctx.GlobalFlags)
 	})
 }
 
@@ -18,7 +18,7 @@ type UsersGetCmd struct {
 }
 
 func (u *UsersGetCmd) Run(ctx *CLIContext) error {
-	return runInstrumented(ctx, "users.get", []string{u.UserID}, func() {
-		handleUserGet(ctx.Context, ctx.Client, []string{u.UserID}, ctx.GlobalFlags)
+	return runInstrumented(ctx, "users.get", []string{u.UserID}, func() error {
+		return handleUserGet(ctx.Context, ctx.Client, []string{u.UserID}, ctx.GlobalFlags)
 	})
 }

--- a/cmd/tdcli/command_workflow.go
+++ b/cmd/tdcli/command_workflow.go
@@ -25,8 +25,8 @@ type WorkflowListCmd struct{}
 
 func (w *WorkflowListCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.list", []string{}, func() {
-		workflow.HandleWorkflowList(ctx.Context, ctx.Client, flags)
+	return runInstrumented(ctx, "workflow.list", []string{}, func() error {
+		return workflow.HandleWorkflowList(ctx.Context, ctx.Client, flags)
 	})
 }
 
@@ -36,8 +36,8 @@ type WorkflowGetCmd struct {
 
 func (w *WorkflowGetCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.get", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
-		workflow.HandleWorkflowGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
+	return runInstrumented(ctx, "workflow.get", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() error {
+		return workflow.HandleWorkflowGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
 	})
 }
 
@@ -49,8 +49,8 @@ type WorkflowCreateCmd struct {
 
 func (w *WorkflowCreateCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.create", []string{w.Name, w.Project}, func() {
-		workflow.HandleWorkflowCreate(ctx.Context, ctx.Client, []string{w.Name, w.Project, w.Config}, flags)
+	return runInstrumented(ctx, "workflow.create", []string{w.Name, w.Project}, func() error {
+		return workflow.HandleWorkflowCreate(ctx.Context, ctx.Client, []string{w.Name, w.Project, w.Config}, flags)
 	})
 }
 
@@ -62,8 +62,8 @@ type WorkflowUpdateCmd struct {
 func (w *WorkflowUpdateCmd) Run(ctx *CLIContext) error {
 	args := append([]string{fmt.Sprintf("%d", w.WorkflowID)}, w.Updates...)
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.update", args, func() {
-		workflow.HandleWorkflowUpdate(ctx.Context, ctx.Client, args, flags)
+	return runInstrumented(ctx, "workflow.update", args, func() error {
+		return workflow.HandleWorkflowUpdate(ctx.Context, ctx.Client, args, flags)
 	})
 }
 
@@ -73,8 +73,8 @@ type WorkflowDeleteCmd struct {
 
 func (w *WorkflowDeleteCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.delete", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
-		workflow.HandleWorkflowDelete(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
+	return runInstrumented(ctx, "workflow.delete", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() error {
+		return workflow.HandleWorkflowDelete(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
 	})
 }
 
@@ -89,8 +89,8 @@ func (w *WorkflowStartCmd) Run(ctx *CLIContext) error {
 		args = append(args, w.Params)
 	}
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.start", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
-		workflow.HandleWorkflowStart(ctx.Context, ctx.Client, args, flags)
+	return runInstrumented(ctx, "workflow.start", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() error {
+		return workflow.HandleWorkflowStart(ctx.Context, ctx.Client, args, flags)
 	})
 }
 
@@ -107,8 +107,8 @@ type WorkflowAttemptsListCmd struct {
 
 func (w *WorkflowAttemptsListCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.attempts.list", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
-		workflow.HandleWorkflowAttemptList(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
+	return runInstrumented(ctx, "workflow.attempts.list", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() error {
+		return workflow.HandleWorkflowAttemptList(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
 	})
 }
 
@@ -119,8 +119,8 @@ type WorkflowAttemptsGetCmd struct {
 
 func (w *WorkflowAttemptsGetCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.attempts.get", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() {
-		workflow.HandleWorkflowAttemptGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
+	return runInstrumented(ctx, "workflow.attempts.get", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() error {
+		return workflow.HandleWorkflowAttemptGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
 	})
 }
 
@@ -131,8 +131,8 @@ type WorkflowAttemptsKillCmd struct {
 
 func (w *WorkflowAttemptsKillCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.attempts.kill", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() {
-		workflow.HandleWorkflowAttemptKill(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
+	return runInstrumented(ctx, "workflow.attempts.kill", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() error {
+		return workflow.HandleWorkflowAttemptKill(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
 	})
 }
 
@@ -148,8 +148,8 @@ func (w *WorkflowAttemptsRetryCmd) Run(ctx *CLIContext) error {
 		args = append(args, w.Params)
 	}
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.attempts.retry", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() {
-		workflow.HandleWorkflowAttemptRetry(ctx.Context, ctx.Client, args, flags)
+	return runInstrumented(ctx, "workflow.attempts.retry", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() error {
+		return workflow.HandleWorkflowAttemptRetry(ctx.Context, ctx.Client, args, flags)
 	})
 }
 
@@ -166,8 +166,8 @@ type WorkflowScheduleGetCmd struct {
 
 func (w *WorkflowScheduleGetCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.schedule.get", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
-		workflow.HandleWorkflowScheduleGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
+	return runInstrumented(ctx, "workflow.schedule.get", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() error {
+		return workflow.HandleWorkflowScheduleGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
 	})
 }
 
@@ -177,8 +177,8 @@ type WorkflowScheduleEnableCmd struct {
 
 func (w *WorkflowScheduleEnableCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.schedule.enable", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
-		workflow.HandleWorkflowScheduleEnable(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
+	return runInstrumented(ctx, "workflow.schedule.enable", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() error {
+		return workflow.HandleWorkflowScheduleEnable(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
 	})
 }
 
@@ -188,8 +188,8 @@ type WorkflowScheduleDisableCmd struct {
 
 func (w *WorkflowScheduleDisableCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.schedule.disable", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
-		workflow.HandleWorkflowScheduleDisable(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
+	return runInstrumented(ctx, "workflow.schedule.disable", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() error {
+		return workflow.HandleWorkflowScheduleDisable(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID)}, flags)
 	})
 }
 
@@ -202,8 +202,8 @@ type WorkflowScheduleUpdateCmd struct {
 
 func (w *WorkflowScheduleUpdateCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.schedule.update", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() {
-		workflow.HandleWorkflowScheduleUpdate(ctx.Context, ctx.Client, []string{
+	return runInstrumented(ctx, "workflow.schedule.update", []string{fmt.Sprintf("%d", w.WorkflowID)}, func() error {
+		return workflow.HandleWorkflowScheduleUpdate(ctx.Context, ctx.Client, []string{
 			fmt.Sprintf("%d", w.WorkflowID), w.Cron, w.Timezone, fmt.Sprintf("%d", w.Delay),
 		}, flags)
 	})
@@ -221,8 +221,8 @@ type WorkflowTasksListCmd struct {
 
 func (w *WorkflowTasksListCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.tasks.list", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() {
-		workflow.HandleWorkflowTaskList(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
+	return runInstrumented(ctx, "workflow.tasks.list", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() error {
+		return workflow.HandleWorkflowTaskList(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
 	})
 }
 
@@ -234,8 +234,8 @@ type WorkflowTasksGetCmd struct {
 
 func (w *WorkflowTasksGetCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.tasks.get", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, func() {
-		workflow.HandleWorkflowTaskGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, flags)
+	return runInstrumented(ctx, "workflow.tasks.get", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, func() error {
+		return workflow.HandleWorkflowTaskGet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, flags)
 	})
 }
 
@@ -251,8 +251,8 @@ type WorkflowLogsAttemptCmd struct {
 
 func (w *WorkflowLogsAttemptCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.logs.attempt", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() {
-		workflow.HandleWorkflowAttemptLog(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
+	return runInstrumented(ctx, "workflow.logs.attempt", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, func() error {
+		return workflow.HandleWorkflowAttemptLog(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID)}, flags)
 	})
 }
 
@@ -264,8 +264,8 @@ type WorkflowLogsTaskCmd struct {
 
 func (w *WorkflowLogsTaskCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.logs.task", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, func() {
-		workflow.HandleWorkflowTaskLog(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, flags)
+	return runInstrumented(ctx, "workflow.logs.task", []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, func() error {
+		return workflow.HandleWorkflowTaskLog(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.WorkflowID), fmt.Sprintf("%d", w.AttemptID), w.TaskID}, flags)
 	})
 }
 
@@ -275,8 +275,8 @@ type WorkflowInitCmd struct {
 
 func (w *WorkflowInitCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.init", []string{w.ProjectName}, func() {
-		workflow.HandleWorkflowInit(ctx.Context, []string{w.ProjectName}, flags)
+	return runInstrumented(ctx, "workflow.init", []string{w.ProjectName}, func() error {
+		return workflow.HandleWorkflowInit(ctx.Context, []string{w.ProjectName}, flags)
 	})
 }
 
@@ -295,8 +295,8 @@ type WorkflowProjectsListCmd struct{}
 
 func (w *WorkflowProjectsListCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.list", []string{}, func() {
-		workflow.HandleWorkflowProjectList(ctx.Context, ctx.Client, flags)
+	return runInstrumented(ctx, "workflow.projects.list", []string{}, func() error {
+		return workflow.HandleWorkflowProjectList(ctx.Context, ctx.Client, flags)
 	})
 }
 
@@ -306,8 +306,8 @@ type WorkflowProjectsGetCmd struct {
 
 func (w *WorkflowProjectsGetCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.get", []string{w.ProjectID}, func() {
-		workflow.HandleWorkflowProjectGet(ctx.Context, ctx.Client, []string{w.ProjectID}, flags)
+	return runInstrumented(ctx, "workflow.projects.get", []string{w.ProjectID}, func() error {
+		return workflow.HandleWorkflowProjectGet(ctx.Context, ctx.Client, []string{w.ProjectID}, flags)
 	})
 }
 
@@ -318,8 +318,8 @@ type WorkflowProjectsCreateCmd struct {
 
 func (w *WorkflowProjectsCreateCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.create", []string{w.Name}, func() {
-		workflow.HandleWorkflowProjectCreate(ctx.Context, ctx.Client, []string{w.Name, w.Path}, flags)
+	return runInstrumented(ctx, "workflow.projects.create", []string{w.Name}, func() error {
+		return workflow.HandleWorkflowProjectCreate(ctx.Context, ctx.Client, []string{w.Name, w.Path}, flags)
 	})
 }
 
@@ -330,8 +330,8 @@ type WorkflowProjectsPushCmd struct {
 
 func (w *WorkflowProjectsPushCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.push", []string{w.Name}, func() {
-		workflow.HandleWorkflowProjectCreate(ctx.Context, ctx.Client, []string{w.Name, w.Path}, flags)
+	return runInstrumented(ctx, "workflow.projects.push", []string{w.Name}, func() error {
+		return workflow.HandleWorkflowProjectCreate(ctx.Context, ctx.Client, []string{w.Name, w.Path}, flags)
 	})
 }
 
@@ -347,8 +347,8 @@ func (w *WorkflowProjectsDownloadCmd) Run(ctx *CLIContext) error {
 		args = append(args, w.OutputDir)
 	}
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.download", []string{w.ProjectIdentifier}, func() {
-		workflow.HandleWorkflowProjectDownload(ctx.Context, ctx.Client, args, flags)
+	return runInstrumented(ctx, "workflow.projects.download", []string{w.ProjectIdentifier}, func() error {
+		return workflow.HandleWorkflowProjectDownload(ctx.Context, ctx.Client, args, flags)
 	})
 }
 
@@ -358,8 +358,8 @@ type WorkflowProjectsWorkflowsCmd struct {
 
 func (w *WorkflowProjectsWorkflowsCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.workflows", []string{fmt.Sprintf("%d", w.ProjectID)}, func() {
-		workflow.HandleWorkflowProjectWorkflows(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.ProjectID)}, flags)
+	return runInstrumented(ctx, "workflow.projects.workflows", []string{fmt.Sprintf("%d", w.ProjectID)}, func() error {
+		return workflow.HandleWorkflowProjectWorkflows(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.ProjectID)}, flags)
 	})
 }
 
@@ -375,8 +375,8 @@ type WorkflowProjectsSecretsListCmd struct {
 
 func (w *WorkflowProjectsSecretsListCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.secrets.list", []string{fmt.Sprintf("%d", w.ProjectID)}, func() {
-		workflow.HandleWorkflowProjectSecretsList(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.ProjectID)}, flags)
+	return runInstrumented(ctx, "workflow.projects.secrets.list", []string{fmt.Sprintf("%d", w.ProjectID)}, func() error {
+		return workflow.HandleWorkflowProjectSecretsList(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.ProjectID)}, flags)
 	})
 }
 
@@ -388,8 +388,8 @@ type WorkflowProjectsSecretsSetCmd struct {
 
 func (w *WorkflowProjectsSecretsSetCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.secrets.set", []string{fmt.Sprintf("%d", w.ProjectID), w.Key}, func() {
-		workflow.HandleWorkflowProjectSecretsSet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.ProjectID), w.Key, w.Value}, flags)
+	return runInstrumented(ctx, "workflow.projects.secrets.set", []string{fmt.Sprintf("%d", w.ProjectID), w.Key}, func() error {
+		return workflow.HandleWorkflowProjectSecretsSet(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.ProjectID), w.Key, w.Value}, flags)
 	})
 }
 
@@ -400,8 +400,8 @@ type WorkflowProjectsSecretsDeleteCmd struct {
 
 func (w *WorkflowProjectsSecretsDeleteCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.secrets.delete", []string{fmt.Sprintf("%d", w.ProjectID), w.Key}, func() {
-		workflow.HandleWorkflowProjectSecretsDelete(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.ProjectID), w.Key}, flags)
+	return runInstrumented(ctx, "workflow.projects.secrets.delete", []string{fmt.Sprintf("%d", w.ProjectID), w.Key}, func() error {
+		return workflow.HandleWorkflowProjectSecretsDelete(ctx.Context, ctx.Client, []string{fmt.Sprintf("%d", w.ProjectID), w.Key}, flags)
 	})
 }
 
@@ -419,8 +419,8 @@ type WorkflowProjectsHooksShowCmd struct {
 
 func (w *WorkflowProjectsHooksShowCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.hooks.show", []string{w.Path}, func() {
-		workflow.HandleWorkflowHooksShow(ctx.Context, ctx.Client, []string{w.Path}, flags)
+	return runInstrumented(ctx, "workflow.projects.hooks.show", []string{w.Path}, func() error {
+		return workflow.HandleWorkflowHooksShow(ctx.Context, ctx.Client, []string{w.Path}, flags)
 	})
 }
 
@@ -430,8 +430,8 @@ type WorkflowProjectsHooksInitCmd struct {
 
 func (w *WorkflowProjectsHooksInitCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.hooks.init", []string{w.Path}, func() {
-		workflow.HandleWorkflowHooksInit(ctx.Context, ctx.Client, []string{w.Path}, flags)
+	return runInstrumented(ctx, "workflow.projects.hooks.init", []string{w.Path}, func() error {
+		return workflow.HandleWorkflowHooksInit(ctx.Context, ctx.Client, []string{w.Path}, flags)
 	})
 }
 
@@ -448,8 +448,8 @@ func (w *WorkflowProjectsHooksAddCmd) Run(ctx *CLIContext) error {
 	args := []string{w.Path, w.Name, fmt.Sprintf("%d", w.Timeout), fmt.Sprintf("%t", w.FailOnError), w.WorkingDir}
 	args = append(args, w.Command...)
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.hooks.add", []string{w.Path, w.Name}, func() {
-		workflow.HandleWorkflowHooksAdd(ctx.Context, ctx.Client, args, flags)
+	return runInstrumented(ctx, "workflow.projects.hooks.add", []string{w.Path, w.Name}, func() error {
+		return workflow.HandleWorkflowHooksAdd(ctx.Context, ctx.Client, args, flags)
 	})
 }
 
@@ -460,8 +460,8 @@ type WorkflowProjectsHooksRemoveCmd struct {
 
 func (w *WorkflowProjectsHooksRemoveCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.hooks.remove", []string{w.Path, w.Name}, func() {
-		workflow.HandleWorkflowHooksRemove(ctx.Context, ctx.Client, []string{w.Path, w.Name}, flags)
+	return runInstrumented(ctx, "workflow.projects.hooks.remove", []string{w.Path, w.Name}, func() error {
+		return workflow.HandleWorkflowHooksRemove(ctx.Context, ctx.Client, []string{w.Path, w.Name}, flags)
 	})
 }
 
@@ -471,7 +471,7 @@ type WorkflowProjectsHooksTestCmd struct {
 
 func (w *WorkflowProjectsHooksTestCmd) Run(ctx *CLIContext) error {
 	flags := workflow.Flags(ctx.GlobalFlags)
-	return runInstrumented(ctx, "workflow.projects.hooks.test", []string{w.Path}, func() {
-		workflow.HandleWorkflowHooksValidate(ctx.Context, ctx.Client, []string{w.Path}, flags)
+	return runInstrumented(ctx, "workflow.projects.hooks.test", []string{w.Path}, func() error {
+		return workflow.HandleWorkflowHooksValidate(ctx.Context, ctx.Client, []string{w.Path}, flags)
 	})
 }

--- a/cmd/tdcli/databases.go
+++ b/cmd/tdcli/databases.go
@@ -2,72 +2,19 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"text/tabwriter"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-func handleDatabaseCommands(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	if len(args) == 0 || args[0] == "help" {
-		printDatabaseUsage()
-		return
-	}
-
-	subcommand := args[0]
-	subArgs := args[1:]
-
-	switch subcommand {
-	case "list", "ls":
-		handleDatabaseList(ctx, client, flags)
-	case "get", "show":
-		handleDatabaseGet(ctx, client, subArgs, flags)
-	case "create":
-		handleDatabaseCreate(ctx, client, subArgs, flags)
-	case "delete", "rm":
-		handleDatabaseDelete(ctx, client, subArgs, flags)
-	case "update":
-		handleDatabaseUpdate(ctx, client, subArgs, flags)
-	default:
-		fmt.Printf("Unknown database subcommand: %s\n", subcommand)
-		printDatabaseUsage()
-		os.Exit(1)
-	}
-}
-
-func printDatabaseUsage() {
-	fmt.Printf(`Database Management Commands
-
-USAGE:
-    tdcli databases <subcommand> [options]
-    tdcli db <subcommand> [options]
-
-SUBCOMMANDS:
-    list, ls              List all databases
-    get, show <name>      Get database details
-    create <name>         Create a new database
-    delete, rm <name>     Delete a database
-    update <name>         Update database properties
-
-OPTIONS:
-    --format FORMAT       Output format (json, table, csv)
-    --verbose, -v         Verbose output
-
-EXAMPLES:
-    tdcli db list
-    tdcli db show my_database
-    tdcli db create new_database
-    tdcli db delete old_database
-    tdcli db update my_database --permission full
-
-`)
-}
-
-func handleDatabaseList(ctx context.Context, client *td.Client, flags Flags) {
+func handleDatabaseList(ctx context.Context, client *td.Client, flags Flags) error {
 	databases, err := client.Databases.List(ctx)
-	handleError(err, "Failed to list databases", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to list databases", flags.Verbose)
+	}
 
 	csvFormatter := func(data interface{}) string {
 		databases := data.([]td.Database)
@@ -106,20 +53,21 @@ func handleDatabaseList(ctx context.Context, client *td.Client, flags Flags) {
 	}
 
 	if err := formatAndWriteOutput(databases, flags.Format, flags.Output, "name,tables,created,updated,permission", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapErr(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
-func handleDatabaseGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleDatabaseGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Database name required")
-		fmt.Println("Usage: tdcli db get <database_name>")
-		os.Exit(1)
+		return errors.New("database name required\nUsage: tdcli db get <database_name>")
 	}
 
 	name := args[0]
 	database, err := client.Databases.Get(ctx, name)
-	handleError(err, "Failed to get database", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to get database", flags.Verbose)
+	}
 
 	csvFormatter := func(data interface{}) string {
 		db := data.(*td.Database)
@@ -147,20 +95,21 @@ func handleDatabaseGet(ctx context.Context, client *td.Client, args []string, fl
 	}
 
 	if err := formatAndWriteOutput(database, flags.Format, flags.Output, "name,tables,created,updated,permission", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapErr(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
-func handleDatabaseCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleDatabaseCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Database name required")
-		fmt.Println("Usage: tdcli db create <database_name>")
-		os.Exit(1)
+		return errors.New("database name required\nUsage: tdcli db create <database_name>")
 	}
 
 	name := args[0]
 	database, err := client.Databases.Create(ctx, name)
-	handleError(err, "Failed to create database", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to create database", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully created database: %s\n", database.Name)
@@ -183,53 +132,52 @@ func handleDatabaseCreate(ctx context.Context, client *td.Client, args []string,
 	}
 
 	if err := formatAndWriteOutput(database, flags.Format, flags.Output, "name,tables,created,updated,permission", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapErr(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
-func handleDatabaseDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleDatabaseDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Database name required")
-		fmt.Println("Usage: tdcli db delete <database_name>")
-		os.Exit(1)
+		return errors.New("database name required\nUsage: tdcli db delete <database_name>")
 	}
 
 	name := args[0]
 
-	// Confirm deletion
 	fmt.Printf("Are you sure you want to delete database '%s'? (y/N): ", name)
 	var response string
 	fmt.Scanln(&response)
 
 	if response != "y" && response != "Y" && response != "yes" && response != "Yes" {
 		fmt.Println("Deletion cancelled")
-		return
+		return nil
 	}
 
-	err := client.Databases.Delete(ctx, name)
-	handleError(err, "Failed to delete database", flags.Verbose)
+	if err := client.Databases.Delete(ctx, name); err != nil {
+		return wrapErr(err, "failed to delete database", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully deleted database: %s\n", name)
 	} else {
 		fmt.Printf("Deleted database: %s\n", name)
 	}
+	return nil
 }
 
-func handleDatabaseUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleDatabaseUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Database name required")
-		fmt.Println("Usage: tdcli db update <database_name> --permission <permission>")
-		os.Exit(1)
+		return errors.New("database name required\nUsage: tdcli db update <database_name> --permission <permission>")
 	}
 
 	name := args[0]
 
-	// For now, we'll just get and display the database
-	// The actual update functionality would depend on what database properties can be updated
 	database, err := client.Databases.Get(ctx, name)
-	handleError(err, "Failed to get database for update", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to get database for update", flags.Verbose)
+	}
 
 	fmt.Printf("Database update functionality would be implemented here for: %s\n", database.Name)
 	fmt.Println("Note: Check Treasure Data API documentation for updateable database properties")
+	return nil
 }

--- a/cmd/tdcli/jobs.go
+++ b/cmd/tdcli/jobs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -9,63 +10,16 @@ import (
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-func handleJobCommands(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	if len(args) == 0 || args[0] == "help" {
-		printJobUsage()
-		return
-	}
-
-	subcommand := args[0]
-	subArgs := args[1:]
-
-	switch subcommand {
-	case "list", "ls":
-		handleJobList(ctx, client, flags)
-	case "get", "show":
-		handleJobGet(ctx, client, subArgs, flags)
-	case "cancel", "kill":
-		handleJobCancel(ctx, client, subArgs, flags)
-	default:
-		fmt.Printf("Unknown job subcommand: %s\n", subcommand)
-		printJobUsage()
-		os.Exit(1)
-	}
-}
-
-func printJobUsage() {
-	fmt.Printf(`Job Management Commands
-
-USAGE:
-    tdcli jobs <subcommand> [options]
-    tdcli job <subcommand> [options]
-
-SUBCOMMANDS:
-    list, ls               List jobs
-    get, show <job_id>     Get job details
-    cancel, kill <job_id>  Cancel a running job
-
-OPTIONS:
-    --status STATUS        Filter by job status
-    --format FORMAT        Output format (json, table, csv)
-    --verbose, -v          Verbose output
-
-EXAMPLES:
-    tdcli job list
-    tdcli job list --status running
-    tdcli job show 12345
-    tdcli job cancel 12345
-
-`)
-}
-
-func handleJobList(ctx context.Context, client *td.Client, flags Flags) {
+func handleJobList(ctx context.Context, client *td.Client, flags Flags) error {
 	var opts *td.JobListOptions
 	if flags.Status != "" {
 		opts = &td.JobListOptions{Status: flags.Status}
 	}
 
 	jobsResp, err := client.Jobs.List(ctx, opts)
-	handleError(err, "Failed to list jobs", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to list jobs", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -75,18 +29,19 @@ func handleJobList(ctx context.Context, client *td.Client, flags Flags) {
 	default:
 		printJobsTable(jobsResp.Jobs)
 	}
+	return nil
 }
 
-func handleJobGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleJobGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Job ID required")
-		fmt.Println("Usage: tdcli job get <job_id>")
-		os.Exit(1)
+		return errors.New("job ID required\nUsage: tdcli job get <job_id>")
 	}
 
 	jobID := args[0]
 	job, err := client.Jobs.Get(ctx, jobID)
-	handleError(err, "Failed to get job", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to get job", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -94,31 +49,31 @@ func handleJobGet(ctx context.Context, client *td.Client, args []string, flags F
 	default:
 		printJobDetails(*job)
 	}
+	return nil
 }
 
-func handleJobCancel(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleJobCancel(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Job ID required")
-		fmt.Println("Usage: tdcli job cancel <job_id>")
-		os.Exit(1)
+		return errors.New("job ID required\nUsage: tdcli job cancel <job_id>")
 	}
 
 	jobID := args[0]
 
-	// Confirm cancellation
 	fmt.Printf("Are you sure you want to cancel job '%s'? (y/N): ", jobID)
 	var response string
 	fmt.Scanln(&response)
 
 	if response != "y" && response != "Y" && response != "yes" && response != "Yes" {
 		fmt.Println("Cancellation cancelled")
-		return
+		return nil
 	}
 
-	err := client.Jobs.Kill(ctx, jobID)
-	handleError(err, "Failed to cancel job", flags.Verbose)
+	if err := client.Jobs.Kill(ctx, jobID); err != nil {
+		return wrapErr(err, "failed to cancel job", flags.Verbose)
+	}
 
 	fmt.Printf("Job %s cancelled\n", jobID)
+	return nil
 }
 
 func printJobDetails(job td.Job) {

--- a/cmd/tdcli/llm.go
+++ b/cmd/tdcli/llm.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -11,16 +12,18 @@ import (
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-func handleLLMActionList(ctx context.Context, client *td.Client, flags Flags) {
+func handleLLMActionList(ctx context.Context, client *td.Client, flags Flags) error {
+	if client == nil {
+		return errors.New("client is not initialized")
+	}
 	resp, err := client.LLM.ListActions(ctx)
 	if err != nil {
-		handleError(err, "Failed to list LLM actions", flags.Verbose)
-		return
+		return wrapErr(err, "failed to list LLM actions", flags.Verbose)
 	}
 
 	if flags.Format == "json" {
 		printJSON(resp)
-		return
+		return nil
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -30,24 +33,25 @@ func handleLLMActionList(ctx context.Context, client *td.Client, flags Flags) {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", action.ID, action.Type, action.IntegrationID, action.PromptID, tagStr)
 	}
 	w.Flush()
+	return nil
 }
 
-func handleLLMActionGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleLLMActionGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	if client == nil {
+		return errors.New("client is not initialized")
+	}
 	if len(args) < 1 {
-		fmt.Println("Usage: tdcli llm actions get <action-id>")
-		return
+		return errors.New("usage: tdcli llm actions get <action-id>")
 	}
 
-	actionID := args[0]
-	resp, err := client.LLM.GetAction(ctx, actionID)
+	resp, err := client.LLM.GetAction(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get LLM action", flags.Verbose)
-		return
+		return wrapErr(err, "failed to get LLM action", flags.Verbose)
 	}
 
 	if flags.Format == "json" {
 		printJSON(resp)
-		return
+		return nil
 	}
 
 	action := resp.Data
@@ -59,12 +63,15 @@ func handleLLMActionGet(ctx context.Context, client *td.Client, args []string, f
 	if len(action.UITags) > 0 {
 		fmt.Printf("UI Tags:     %s\n", strings.Join(action.UITags, ", "))
 	}
+	return nil
 }
 
-func handleLLMActionExecute(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleLLMActionExecute(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	if client == nil {
+		return errors.New("client is not initialized")
+	}
 	if len(args) < 2 {
-		fmt.Println("Usage: tdcli llm actions execute <action-id> <json-input>")
-		return
+		return errors.New("usage: tdcli llm actions execute <action-id> <json-input>")
 	}
 
 	actionID := args[0]
@@ -72,29 +79,30 @@ func handleLLMActionExecute(ctx context.Context, client *td.Client, args []strin
 
 	var input map[string]interface{}
 	if err := json.Unmarshal([]byte(inputStr), &input); err != nil {
-		handleError(err, "Failed to parse input JSON", flags.Verbose)
-		return
+		return wrapErr(err, "failed to parse input JSON", flags.Verbose)
 	}
 
 	resp, err := client.LLM.ExecuteAction(ctx, actionID, input)
 	if err != nil {
-		handleError(err, "Failed to execute LLM action", flags.Verbose)
-		return
+		return wrapErr(err, "failed to execute LLM action", flags.Verbose)
 	}
 
 	printJSON(resp)
+	return nil
 }
 
-func handleLLMIntegrationList(ctx context.Context, client *td.Client, flags Flags) {
+func handleLLMIntegrationList(ctx context.Context, client *td.Client, flags Flags) error {
+	if client == nil {
+		return errors.New("client is not initialized")
+	}
 	resp, err := client.LLM.ListIntegrations(ctx)
 	if err != nil {
-		handleError(err, "Failed to list LLM integrations", flags.Verbose)
-		return
+		return wrapErr(err, "failed to list LLM integrations", flags.Verbose)
 	}
 
 	if flags.Format == "json" {
 		printJSON(resp)
-		return
+		return nil
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -103,18 +111,21 @@ func handleLLMIntegrationList(ctx context.Context, client *td.Client, flags Flag
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", integration.ID, integration.Name, integration.Type, integration.Status)
 	}
 	w.Flush()
+	return nil
 }
 
-func handleLLMPromptList(ctx context.Context, client *td.Client, flags Flags) {
+func handleLLMPromptList(ctx context.Context, client *td.Client, flags Flags) error {
+	if client == nil {
+		return errors.New("client is not initialized")
+	}
 	resp, err := client.LLM.ListPrompts(ctx)
 	if err != nil {
-		handleError(err, "Failed to list LLM prompts", flags.Verbose)
-		return
+		return wrapErr(err, "failed to list LLM prompts", flags.Verbose)
 	}
 
 	if flags.Format == "json" {
 		printJSON(resp)
-		return
+		return nil
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -124,18 +135,21 @@ func handleLLMPromptList(ctx context.Context, client *td.Client, flags Flags) {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", prompt.ID, prompt.Name, prompt.Status, varsStr)
 	}
 	w.Flush()
+	return nil
 }
 
-func handleLLMProjectList(ctx context.Context, client *td.Client, flags Flags) {
+func handleLLMProjectList(ctx context.Context, client *td.Client, flags Flags) error {
+	if client == nil {
+		return errors.New("client is not initialized")
+	}
 	resp, err := client.LLM.ListProjects(ctx)
 	if err != nil {
-		handleError(err, "Failed to list LLM projects", flags.Verbose)
-		return
+		return wrapErr(err, "failed to list LLM projects", flags.Verbose)
 	}
 
 	if flags.Format == "json" {
 		printJSON(resp)
-		return
+		return nil
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -144,24 +158,25 @@ func handleLLMProjectList(ctx context.Context, client *td.Client, flags Flags) {
 		fmt.Fprintf(w, "%s\t%s\t%s\n", project.ID, project.Name, project.Status)
 	}
 	w.Flush()
+	return nil
 }
 
-func handleLLMProjectGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleLLMProjectGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	if client == nil {
+		return errors.New("client is not initialized")
+	}
 	if len(args) < 1 {
-		fmt.Println("Usage: tdcli llm projects get <project-id>")
-		return
+		return errors.New("usage: tdcli llm projects get <project-id>")
 	}
 
-	projectID := args[0]
-	project, err := client.LLM.GetProject(ctx, projectID)
+	project, err := client.LLM.GetProject(ctx, args[0])
 	if err != nil {
-		handleError(err, "Failed to get LLM project", flags.Verbose)
-		return
+		return wrapErr(err, "failed to get LLM project", flags.Verbose)
 	}
 
 	if flags.Format == "json" {
 		printJSON(project)
-		return
+		return nil
 	}
 
 	fmt.Printf("ID:          %s\n", project.ID)
@@ -170,4 +185,5 @@ func handleLLMProjectGet(ctx context.Context, client *td.Client, args []string, 
 	if project.Description != "" {
 		fmt.Printf("Description: %s\n", project.Description)
 	}
+	return nil
 }

--- a/cmd/tdcli/main.go
+++ b/cmd/tdcli/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -207,11 +208,9 @@ func main() {
 		OTELManager: otelManager,
 	}
 
-	// Execute the command
+	// Execute the command. Handlers return errors which we display here.
 	err = ctx.Run(cliContext)
-	if err != nil {
-		handleError(err, "Command failed", cli.Verbose)
-	}
+	reportError(err, "Command failed", cli.Verbose)
 }
 
 func isValidAPIKey(apiKey string) bool {
@@ -221,23 +220,32 @@ func isValidAPIKey(apiKey string) bool {
 	return len(parts) == 2 && len(parts[0]) > 0 && len(parts[1]) > 0
 }
 
-func handleError(err error, message string, verbose bool) {
-	if err != nil {
-		if captureHandlerErrors {
-			// When in capture mode, panic with the error instead of calling os.Exit
-			if verbose {
-				panic(fmt.Errorf("%s: %v", message, err))
-			} else {
-				panic(err)
-			}
-		} else {
-			// Original behavior - exit the program
-			if verbose {
-				log.Fatalf("%s: %v", message, err)
-			} else {
-				fmt.Printf("Error: %s\n", err.Error())
-				os.Exit(1)
-			}
+// reportError displays a top-level command error and exits non-zero.
+// Used only by main() once Kong has finished dispatch; handlers themselves
+// return errors so they propagate naturally up the call stack.
+func reportError(err error, message string, verbose bool) {
+	if err == nil {
+		return
+	}
+	if verbose {
+		log.Fatalf("%s: %v", message, err)
+	}
+	fmt.Printf("Error: %s\n", err.Error())
+	os.Exit(1)
+}
+
+// wrapErr formats an error with context for propagation. When verbose, it
+// includes status/message details for TD API errors so verbose runs surface
+// the same information the previous log.Fatal helpers used to print.
+func wrapErr(err error, message string, verbose bool) error {
+	if err == nil {
+		return nil
+	}
+	if verbose {
+		var tdErr *td.ErrorResponse
+		if errors.As(err, &tdErr) && tdErr.Response != nil {
+			return fmt.Errorf("%s: %w (status: %d, message: %s)", message, err, tdErr.Response.StatusCode, tdErr.Message)
 		}
 	}
+	return fmt.Errorf("%s: %w", message, err)
 }

--- a/cmd/tdcli/permissions.go
+++ b/cmd/tdcli/permissions.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -10,109 +11,11 @@ import (
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-func handlePermissionCommands(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	if len(args) == 0 || args[0] == "help" {
-		printPermissionUsage()
-		return
-	}
-
-	subcommand := args[0]
-	subArgs := args[1:]
-
-	switch subcommand {
-	case "policies":
-		handlePolicyCommands(ctx, client, subArgs, flags)
-	case "groups":
-		handlePolicyGroupCommands(ctx, client, subArgs, flags)
-	case "users":
-		handleAccessControlUserCommands(ctx, client, subArgs, flags)
-	default:
-		fmt.Printf("Unknown permission subcommand: %s\n", subcommand)
-		printPermissionUsage()
-		os.Exit(1)
-	}
-}
-
-func printPermissionUsage() {
-	fmt.Printf(`Access Control and Permissions Commands
-
-USAGE:
-    tdcli permissions <subcommand> [options]
-    tdcli perms <subcommand> [options]
-    tdcli acl <subcommand> [options]
-
-SUBCOMMANDS:
-    policies               Policy management
-    groups                 Policy group management
-    users                  Access control user management
-
-OPTIONS:
-    --format FORMAT        Output format (json, table, csv)
-    --verbose, -v          Verbose output
-
-EXAMPLES:
-    tdcli perms policies list
-    tdcli perms policies create "My Policy"
-    tdcli perms groups list
-    tdcli perms users list
-
-For detailed help on each subcommand:
-    tdcli perms policies help
-    tdcli perms groups help
-    tdcli perms users help
-
-`)
-}
-
-func handlePolicyCommands(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	if len(args) == 0 || args[0] == "help" {
-		printPolicyUsage()
-		return
-	}
-
-	subcommand := args[0]
-	subArgs := args[1:]
-
-	switch subcommand {
-	case "list", "ls":
-		handlePolicyList(ctx, client, flags)
-	case "get", "show":
-		handlePolicyGet(ctx, client, subArgs, flags)
-	case "create":
-		handlePolicyCreate(ctx, client, subArgs, flags)
-	case "delete", "rm":
-		handlePolicyDelete(ctx, client, subArgs, flags)
-	default:
-		fmt.Printf("Unknown policy subcommand: %s\n", subcommand)
-		printPolicyUsage()
-		os.Exit(1)
-	}
-}
-
-func printPolicyUsage() {
-	fmt.Printf(`Policy Management Commands
-
-USAGE:
-    tdcli perms policies <subcommand> [options]
-
-SUBCOMMANDS:
-    list, ls               List all policies
-    get, show <id>         Get policy details
-    create <name>          Create a new policy
-    delete, rm <id>        Delete a policy
-
-EXAMPLES:
-    tdcli perms policies list
-    tdcli perms policies show 123
-    tdcli perms policies create "Analytics Policy"
-    tdcli perms policies delete 123
-
-`)
-}
-
-func handlePolicyList(ctx context.Context, client *td.Client, flags Flags) {
+func handlePolicyList(ctx context.Context, client *td.Client, flags Flags) error {
 	policies, err := client.Permissions.ListPolicies(ctx, nil)
-	handleError(err, "Failed to list policies", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to list policies", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -122,24 +25,23 @@ func handlePolicyList(ctx context.Context, client *td.Client, flags Flags) {
 	default:
 		printPoliciesTable(policies)
 	}
+	return nil
 }
 
-func handlePolicyGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handlePolicyGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Policy ID required")
-		fmt.Println("Usage: tdcli perms policies get <policy_id>")
-		os.Exit(1)
+		return errors.New("policy ID required\nUsage: tdcli perms policies get <policy_id>")
 	}
 
-	policyIDStr := args[0]
-	policyID, err := strconv.Atoi(policyIDStr)
+	policyID, err := strconv.Atoi(args[0])
 	if err != nil {
-		fmt.Printf("Error: Invalid policy ID: %s\n", policyIDStr)
-		os.Exit(1)
+		return fmt.Errorf("invalid policy ID: %s", args[0])
 	}
 
 	policy, err := client.Permissions.GetPolicy(ctx, policyID)
-	handleError(err, "Failed to get policy", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to get policy", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -147,13 +49,12 @@ func handlePolicyGet(ctx context.Context, client *td.Client, args []string, flag
 	default:
 		printPolicyDetails(*policy)
 	}
+	return nil
 }
 
-func handlePolicyCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handlePolicyCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Policy name required")
-		fmt.Println("Usage: tdcli perms policies create <name> [description]")
-		os.Exit(1)
+		return errors.New("policy name required\nUsage: tdcli perms policies create <name> [description]")
 	}
 
 	name := args[0]
@@ -163,93 +64,50 @@ func handlePolicyCreate(ctx context.Context, client *td.Client, args []string, f
 	}
 
 	policy, err := client.Permissions.CreatePolicy(ctx, name, description)
-	handleError(err, "Failed to create policy", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to create policy", flags.Verbose)
+	}
 
 	fmt.Printf("Created policy: %s (ID: %d)\n", policy.Name, policy.ID)
 	if flags.Verbose {
 		printPolicyDetails(*policy)
 	}
+	return nil
 }
 
-func handlePolicyDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handlePolicyDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Policy ID required")
-		fmt.Println("Usage: tdcli perms policies delete <policy_id>")
-		os.Exit(1)
+		return errors.New("policy ID required\nUsage: tdcli perms policies delete <policy_id>")
 	}
 
-	policyIDStr := args[0]
-	policyID, err := strconv.Atoi(policyIDStr)
+	policyID, err := strconv.Atoi(args[0])
 	if err != nil {
-		fmt.Printf("Error: Invalid policy ID: %s\n", policyIDStr)
-		os.Exit(1)
+		return fmt.Errorf("invalid policy ID: %s", args[0])
 	}
 
-	// Confirm deletion
 	fmt.Printf("Are you sure you want to delete policy %d? (y/N): ", policyID)
 	var response string
 	fmt.Scanln(&response)
 
 	if response != "y" && response != "Y" && response != "yes" && response != "Yes" {
 		fmt.Println("Deletion cancelled")
-		return
+		return nil
 	}
 
 	deletedPolicy, err := client.Permissions.DeletePolicy(ctx, policyID)
-	handleError(err, "Failed to delete policy", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to delete policy", flags.Verbose)
+	}
 
 	fmt.Printf("Deleted policy: %s (ID: %d)\n", deletedPolicy.Name, deletedPolicy.ID)
+	return nil
 }
 
-func handlePolicyGroupCommands(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	if len(args) == 0 || args[0] == "help" {
-		printPolicyGroupUsage()
-		return
-	}
-
-	subcommand := args[0]
-	subArgs := args[1:]
-
-	switch subcommand {
-	case "list", "ls":
-		handlePolicyGroupList(ctx, client, flags)
-	case "get", "show":
-		handlePolicyGroupGet(ctx, client, subArgs, flags)
-	case "create":
-		handlePolicyGroupCreate(ctx, client, subArgs, flags)
-	case "delete", "rm":
-		handlePolicyGroupDelete(ctx, client, subArgs, flags)
-	default:
-		fmt.Printf("Unknown policy group subcommand: %s\n", subcommand)
-		printPolicyGroupUsage()
-		os.Exit(1)
-	}
-}
-
-func printPolicyGroupUsage() {
-	fmt.Printf(`Policy Group Management Commands
-
-USAGE:
-    tdcli perms groups <subcommand> [options]
-
-SUBCOMMANDS:
-    list, ls               List all policy groups
-    get, show <id>         Get policy group details
-    create <name>          Create a new policy group
-    delete, rm <id>        Delete a policy group
-
-EXAMPLES:
-    tdcli perms groups list
-    tdcli perms groups show 123
-    tdcli perms groups create "Analytics Group"
-    tdcli perms groups delete 123
-
-`)
-}
-
-func handlePolicyGroupList(ctx context.Context, client *td.Client, flags Flags) {
+func handlePolicyGroupList(ctx context.Context, client *td.Client, flags Flags) error {
 	groups, err := client.Permissions.ListPolicyGroups(ctx)
-	handleError(err, "Failed to list policy groups", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to list policy groups", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -259,18 +117,18 @@ func handlePolicyGroupList(ctx context.Context, client *td.Client, flags Flags) 
 	default:
 		printPolicyGroupsTable(groups)
 	}
+	return nil
 }
 
-func handlePolicyGroupGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handlePolicyGroupGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Policy group ID required")
-		fmt.Println("Usage: tdcli perms groups get <group_id>")
-		os.Exit(1)
+		return errors.New("policy group ID required\nUsage: tdcli perms groups get <group_id>")
 	}
 
-	groupID := args[0]
-	group, err := client.Permissions.GetPolicyGroup(ctx, groupID)
-	handleError(err, "Failed to get policy group", flags.Verbose)
+	group, err := client.Permissions.GetPolicyGroup(ctx, args[0])
+	if err != nil {
+		return wrapErr(err, "failed to get policy group", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -278,117 +136,69 @@ func handlePolicyGroupGet(ctx context.Context, client *td.Client, args []string,
 	default:
 		printPolicyGroupDetails(*group)
 	}
+	return nil
 }
 
-func handlePolicyGroupCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handlePolicyGroupCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Policy group name required")
-		fmt.Println("Usage: tdcli perms groups create <name>")
-		os.Exit(1)
+		return errors.New("policy group name required\nUsage: tdcli perms groups create <name>")
 	}
 
-	name := args[0]
-	group, err := client.Permissions.CreatePolicyGroup(ctx, name)
-	handleError(err, "Failed to create policy group", flags.Verbose)
+	group, err := client.Permissions.CreatePolicyGroup(ctx, args[0])
+	if err != nil {
+		return wrapErr(err, "failed to create policy group", flags.Verbose)
+	}
 
 	fmt.Printf("Created policy group: %s (ID: %d)\n", group.Name, group.ID)
 	if flags.Verbose {
 		printPolicyGroupDetails(*group)
 	}
+	return nil
 }
 
-func handlePolicyGroupDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handlePolicyGroupDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Policy group ID required")
-		fmt.Println("Usage: tdcli perms groups delete <group_id>")
-		os.Exit(1)
+		return errors.New("policy group ID required\nUsage: tdcli perms groups delete <group_id>")
 	}
 
 	groupID := args[0]
 
-	// Confirm deletion
 	fmt.Printf("Are you sure you want to delete policy group %s? (y/N): ", groupID)
 	var response string
 	fmt.Scanln(&response)
 
 	if response != "y" && response != "Y" && response != "yes" && response != "Yes" {
 		fmt.Println("Deletion cancelled")
-		return
+		return nil
 	}
 
-	err := client.Permissions.DeletePolicyGroup(ctx, groupID)
-	handleError(err, "Failed to delete policy group", flags.Verbose)
+	if err := client.Permissions.DeletePolicyGroup(ctx, groupID); err != nil {
+		return wrapErr(err, "failed to delete policy group", flags.Verbose)
+	}
 
 	fmt.Printf("Deleted policy group: %s\n", groupID)
+	return nil
 }
 
-func handleAccessControlUserCommands(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	if len(args) == 0 || args[0] == "help" {
-		printAccessControlUserUsage()
-		return
-	}
-
-	subcommand := args[0]
-	subArgs := args[1:]
-
-	switch subcommand {
-	case "list", "ls":
-		handleAccessControlUserList(ctx, client, flags)
-	case "get", "show":
-		handleAccessControlUserGet(ctx, client, subArgs, flags)
-	default:
-		fmt.Printf("Unknown access control user subcommand: %s\n", subcommand)
-		printAccessControlUserUsage()
-		os.Exit(1)
-	}
-}
-
-func printAccessControlUserUsage() {
-	fmt.Printf(`Access Control User Management Commands
-
-USAGE:
-    tdcli perms users <subcommand> [options]
-
-SUBCOMMANDS:
-    list, ls               List access control users
-    get, show <user_id>    Get user access control details
-
-OPTIONS:
-    --with-details         Include user email and name details (default: true)
-    --format FORMAT        Output format (json, table, csv)
-    --verbose, -v          Verbose output
-
-EXAMPLES:
-    tdcli perms users list
-    tdcli perms users list --no-with-details
-    tdcli perms users list --format json
-    tdcli perms users show 12345
-
-`)
-}
-
-func handleAccessControlUserList(ctx context.Context, client *td.Client, flags Flags) {
+func handleAccessControlUserList(ctx context.Context, client *td.Client, flags Flags) error {
 	users, err := client.Permissions.ListAccessControlUsers(ctx)
-	handleError(err, "Failed to list access control users", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to list access control users", flags.Verbose)
+	}
 
 	var userDetailsMap map[int]td.User
 	if flags.WithDetails {
-		// Only fetch user details for the access control users we have
 		userDetailsMap = make(map[int]td.User)
 
-		// Get all users first to avoid N+1 query problem
-		// TODO: Add a method to get user details by specific IDs to optimize further
 		allUsers, err := client.Users.List(ctx)
 		if err != nil && flags.Verbose {
 			fmt.Printf("Warning: Failed to fetch user details: %v\n", err)
 		} else {
-			// Create a set of user IDs we need
 			neededUserIDs := make(map[int]bool)
 			for _, user := range users {
 				neededUserIDs[user.UserID] = true
 			}
 
-			// Only add users we actually need to the map
 			for _, user := range allUsers {
 				if neededUserIDs[user.ID] {
 					userDetailsMap[user.ID] = user
@@ -409,24 +219,23 @@ func handleAccessControlUserList(ctx context.Context, client *td.Client, flags F
 	default:
 		printAccessControlUsersTable(users, userDetailsMap)
 	}
+	return nil
 }
 
-func handleAccessControlUserGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleAccessControlUserGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: User ID required")
-		fmt.Println("Usage: tdcli perms users get <user_id>")
-		os.Exit(1)
+		return errors.New("user ID required\nUsage: tdcli perms users get <user_id>")
 	}
 
-	userIDStr := args[0]
-	userID, err := strconv.Atoi(userIDStr)
+	userID, err := strconv.Atoi(args[0])
 	if err != nil {
-		fmt.Printf("Error: Invalid user ID: %s\n", userIDStr)
-		os.Exit(1)
+		return fmt.Errorf("invalid user ID: %s", args[0])
 	}
 
 	user, err := client.Permissions.GetAccessControlUser(ctx, userID)
-	handleError(err, "Failed to get access control user", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to get access control user", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -434,6 +243,7 @@ func handleAccessControlUserGet(ctx context.Context, client *td.Client, args []s
 	default:
 		printAccessControlUserDetails(*user)
 	}
+	return nil
 }
 
 // Print functions

--- a/cmd/tdcli/personalization.go
+++ b/cmd/tdcli/personalization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -11,11 +12,13 @@ import (
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-func handlePersonalizationSend(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handlePersonalizationSend(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	if client == nil {
+		return errors.New("client is not initialized")
+	}
 	if len(args) < 3 {
-		fmt.Println("Usage: tdcli personalization send <database> <table> <json-data> [--token TOKEN]")
-		fmt.Println("Example: tdcli personalization send mydb mytable '{\"td_client_id\":\"abc123\"}'")
-		return
+		return errors.New("usage: tdcli personalization send <database> <table> <json-data> [--token TOKEN]\n" +
+			"Example: tdcli personalization send mydb mytable '{\"td_client_id\":\"abc123\"}'")
 	}
 
 	database := args[0]
@@ -28,8 +31,7 @@ func handlePersonalizationSend(ctx context.Context, client *td.Client, args []st
 
 	var event map[string]interface{}
 	if err := json.Unmarshal([]byte(dataStr), &event); err != nil {
-		handleError(err, "Failed to parse event JSON", flags.Verbose)
-		return
+		return wrapErr(err, "failed to parse event JSON", flags.Verbose)
 	}
 
 	var resp *td.PersonalizationResponse
@@ -41,32 +43,28 @@ func handlePersonalizationSend(ctx context.Context, client *td.Client, args []st
 	}
 
 	if err != nil {
-		handleError(err, "Failed to send personalization event", flags.Verbose)
-		return
+		return wrapErr(err, "failed to send personalization event", flags.Verbose)
 	}
 
 	if resp == nil || len(resp.Offers) == 0 {
 		fmt.Println("Event sent successfully. No offers returned.")
-		return
+		return nil
 	}
 
 	fmt.Println("Event sent successfully. Matching offers:")
 	outputPersonalizationResponse(resp, flags)
+	return nil
 }
 
 func outputPersonalizationResponse(resp *td.PersonalizationResponse, flags Flags) {
 	switch flags.Format {
 	case "json":
-		outputPersonalizationJSON(resp)
+		printJSON(resp)
 	case "csv":
 		outputPersonalizationCSV(resp)
 	default:
 		outputPersonalizationTable(resp)
 	}
-}
-
-func outputPersonalizationJSON(resp *td.PersonalizationResponse) {
-	printJSON(resp)
 }
 
 func outputPersonalizationCSV(resp *td.PersonalizationResponse) {

--- a/cmd/tdcli/postback.go
+++ b/cmd/tdcli/postback.go
@@ -3,16 +3,19 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-func handlePostbackSend(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handlePostbackSend(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	if client == nil {
+		return errors.New("client is not initialized")
+	}
 	if len(args) < 3 {
-		fmt.Println("Usage: tdcli postback send <database> <table> <json-data>")
-		fmt.Println("Example: tdcli postback send mydb mytable '{\"email\":\"test@example.com\"}'")
-		return
+		return errors.New("usage: tdcli postback send <database> <table> <json-data>\n" +
+			"Example: tdcli postback send mydb mytable '{\"email\":\"test@example.com\"}'")
 	}
 
 	database := args[0]
@@ -21,14 +24,13 @@ func handlePostbackSend(ctx context.Context, client *td.Client, args []string, f
 
 	var event map[string]interface{}
 	if err := json.Unmarshal([]byte(dataStr), &event); err != nil {
-		handleError(err, "Failed to parse event JSON", flags.Verbose)
-		return
+		return wrapErr(err, "failed to parse event JSON", flags.Verbose)
 	}
 
 	if err := client.Postback.SendEvent(ctx, database, table, event); err != nil {
-		handleError(err, "Failed to send postback event", flags.Verbose)
-		return
+		return wrapErr(err, "failed to send postback event", flags.Verbose)
 	}
 
 	fmt.Println("Event sent successfully")
+	return nil
 }

--- a/cmd/tdcli/queries.go
+++ b/cmd/tdcli/queries.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,76 +13,9 @@ import (
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-func handleQueryCommands(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	if len(args) == 0 || args[0] == "help" {
-		printQueryUsage()
-		return
-	}
-
-	subcommand := args[0]
-	subArgs := args[1:]
-
-	switch subcommand {
-	case "submit", "run":
-		handleQuerySubmit(ctx, client, subArgs, flags)
-	case "status":
-		handleQueryStatus(ctx, client, subArgs, flags)
-	case "result", "results":
-		handleQueryResult(ctx, client, subArgs, flags)
-	case "list", "ls":
-		handleQueryList(ctx, client, flags)
-	case "cancel":
-		handleQueryCancel(ctx, client, subArgs, flags)
-	default:
-		fmt.Printf("Unknown query subcommand: %s\n", subcommand)
-		printQueryUsage()
-		os.Exit(1)
-	}
-}
-
-func printQueryUsage() {
-	fmt.Printf(`Query Execution Commands
-
-USAGE:
-    tdcli queries <subcommand> [options]
-    tdcli query <subcommand> [options]
-    tdcli q <subcommand> [options]
-
-SUBCOMMANDS:
-    submit, run <query>    Submit a query for execution
-    status <job_id>        Check query execution status
-    result, results <job_id> Get query results
-    list, ls               List recent queries
-    cancel <job_id>        Cancel a running query
-
-OPTIONS:
-    --database DATABASE    Database to run query against (required for submit)
-    --engine ENGINE        Query engine: trino (default) or hive
-    --priority PRIORITY    Query priority (0-2, default: 0)
-    --result-url URL       Result output URL
-    --type TYPE            Result format type
-    --wait                 Wait for query completion
-    --timeout SECONDS      Wait timeout in seconds (default: 300)
-    --format FORMAT        Output format (json, table, csv)
-    --limit LIMIT          Limit number of result rows
-    --verbose, -v          Verbose output
-
-EXAMPLES:
-    tdcli q submit "SELECT COUNT(*) FROM my_table" --database my_db
-    tdcli q submit "SELECT * FROM users LIMIT 10" --database analytics --wait
-    tdcli q status 12345
-    tdcli q result 12345 --format csv
-    tdcli q list
-    tdcli q cancel 12345
-
-`)
-}
-
-func handleQuerySubmit(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleQuerySubmit(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Query string required")
-		fmt.Println("Usage: tdcli q submit \"<query>\" --database <database>")
-		os.Exit(1)
+		return errors.New("query string required\nUsage: tdcli q submit \"<query>\" --database <database>")
 	}
 
 	query := args[0]
@@ -89,12 +23,9 @@ func handleQuerySubmit(ctx context.Context, client *td.Client, args []string, fl
 	var engine td.QueryType
 
 	if database == "" {
-		fmt.Println("Error: Database name required")
-		fmt.Println("Usage: tdcli q submit \"<query>\" --database <database>")
-		os.Exit(1)
+		return errors.New("database name required\nUsage: tdcli q submit \"<query>\" --database <database>")
 	}
 
-	// Determine query engine - check flag first, then env var, then default
 	if flags.Engine != "" {
 		switch strings.ToLower(flags.Engine) {
 		case "hive":
@@ -113,7 +44,7 @@ func handleQuerySubmit(ctx context.Context, client *td.Client, args []string, fl
 		case "presto":
 			engine = td.QueryTypePresto
 		default:
-			engine = td.QueryTypeTrino // Default to Trino
+			engine = td.QueryTypeTrino
 		}
 	}
 
@@ -131,28 +62,28 @@ func handleQuerySubmit(ctx context.Context, client *td.Client, args []string, fl
 	}
 
 	job, err := client.Queries.Issue(ctx, engine, database, opts)
-	handleError(err, "Failed to submit query", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to submit query", flags.Verbose)
+	}
 
 	fmt.Printf("Query submitted successfully\n")
 	fmt.Printf("Job ID: %s\n", job.JobID)
 
-	// If wait flag is set, wait for completion
 	if os.Getenv("TD_WAIT") == "true" || containsFlag(os.Args, "--wait") {
-		handleQueryWait(ctx, client, job.JobID, flags)
+		return handleQueryWait(ctx, client, job.JobID, flags)
 	}
+	return nil
 }
 
-func handleQueryStatus(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleQueryStatus(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Job ID required")
-		fmt.Println("Usage: tdcli q status <job_id>")
-		os.Exit(1)
+		return errors.New("job ID required\nUsage: tdcli q status <job_id>")
 	}
 
-	jobIDStr := args[0]
-
-	job, err := client.Jobs.Get(ctx, jobIDStr)
-	handleError(err, "Failed to get job status", flags.Verbose)
+	job, err := client.Jobs.Get(ctx, args[0])
+	if err != nil {
+		return wrapErr(err, "failed to get job status", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -160,31 +91,30 @@ func handleQueryStatus(ctx context.Context, client *td.Client, args []string, fl
 	default:
 		printJobDetails(*job)
 	}
+	return nil
 }
 
-func handleQueryResult(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleQueryResult(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Job ID required")
-		fmt.Println("Usage: tdcli q result <job_id>")
-		os.Exit(1)
+		return errors.New("job ID required\nUsage: tdcli q result <job_id>")
 	}
 
 	jobIDStr := args[0]
 
-	// First check if job is completed
 	job, err := client.Jobs.Get(ctx, jobIDStr)
-	handleError(err, "Failed to get job status", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to get job status", flags.Verbose)
+	}
 
 	if job.Status != "success" {
 		fmt.Printf("Job status: %s\n", job.Status)
 		if job.Status == "error" && job.Debug != nil {
 			fmt.Printf("Error: %s\n", job.Debug.Stderr)
 		}
-		return
+		return nil
 	}
 
-	// Get results
-	format := "json" // Default format for API
+	format := "json"
 	if flags.Format == "csv" {
 		format = "csv"
 	}
@@ -196,12 +126,15 @@ func handleQueryResult(ctx context.Context, client *td.Client, args []string, fl
 		opts.Limit = flags.Limit
 	}
 	resultReader, err := client.Results.GetResult(ctx, jobIDStr, opts)
-	handleError(err, "Failed to get query results", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to get query results", flags.Verbose)
+	}
 	defer resultReader.Close()
 
-	// Read all results
 	resultsBytes, err := io.ReadAll(resultReader)
-	handleError(err, "Failed to read query results", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to read query results", flags.Verbose)
+	}
 	results := string(resultsBytes)
 
 	switch flags.Format {
@@ -210,26 +143,27 @@ func handleQueryResult(ctx context.Context, client *td.Client, args []string, fl
 	case "csv":
 		fmt.Print(results)
 	default:
-		// Try to format as table if it's JSON
 		if format == "json" {
 			printQueryResultsTable(results, flags.Limit)
 		} else {
 			fmt.Print(results)
 		}
 	}
+	return nil
 }
 
-func handleQueryList(ctx context.Context, client *td.Client, flags Flags) {
+func handleQueryList(ctx context.Context, client *td.Client, flags Flags) error {
 	var opts *td.JobListOptions
 	if flags.Status != "" {
 		opts = &td.JobListOptions{Status: flags.Status}
 	}
 
 	jobsResp, err := client.Jobs.List(ctx, opts)
-	handleError(err, "Failed to list jobs", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to list jobs", flags.Verbose)
+	}
 	jobs := jobsResp.Jobs
 
-	// Filter to only queries (not other job types)
 	var queryJobs []td.Job
 	for _, job := range jobs {
 		if job.Type == "trino" || job.Type == "hive" || job.Type == "presto" {
@@ -245,25 +179,26 @@ func handleQueryList(ctx context.Context, client *td.Client, flags Flags) {
 	default:
 		printJobsTable(queryJobs)
 	}
+	return nil
 }
 
-func handleQueryCancel(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleQueryCancel(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Job ID required")
-		fmt.Println("Usage: tdcli q cancel <job_id>")
-		os.Exit(1)
+		return errors.New("job ID required\nUsage: tdcli q cancel <job_id>")
 	}
 
 	jobIDStr := args[0]
 
-	err := client.Jobs.Kill(ctx, jobIDStr)
-	handleError(err, "Failed to cancel job", flags.Verbose)
+	if err := client.Jobs.Kill(ctx, jobIDStr); err != nil {
+		return wrapErr(err, "failed to cancel job", flags.Verbose)
+	}
 
 	fmt.Printf("Job %s cancelled\n", jobIDStr)
+	return nil
 }
 
-func handleQueryWait(ctx context.Context, client *td.Client, jobID string, flags Flags) {
-	timeout := 300 // Default 5 minutes
+func handleQueryWait(ctx context.Context, client *td.Client, jobID string, flags Flags) error {
+	timeout := 300
 	if timeoutEnv := os.Getenv("TD_TIMEOUT"); timeoutEnv != "" {
 		if t, err := strconv.Atoi(timeoutEnv); err == nil {
 			timeout = t
@@ -279,18 +214,15 @@ func handleQueryWait(ctx context.Context, client *td.Client, jobID string, flags
 	for {
 		select {
 		case <-ctx.Done():
-			fmt.Println("Context cancelled")
-			return
+			return ctx.Err()
 		case <-ticker.C:
 			if time.Since(start).Seconds() > float64(timeout) {
-				fmt.Printf("Timeout waiting for job %s\n", jobID)
-				return
+				return fmt.Errorf("timeout waiting for job %s", jobID)
 			}
 
 			job, err := client.Jobs.Get(ctx, jobID)
 			if err != nil {
-				fmt.Printf("Error checking job status: %v\n", err)
-				return
+				return wrapErr(err, "failed to check job status", flags.Verbose)
 			}
 
 			switch job.Status {
@@ -299,16 +231,16 @@ func handleQueryWait(ctx context.Context, client *td.Client, jobID string, flags
 				if flags.Verbose {
 					printJobDetails(*job)
 				}
-				return
+				return nil
 			case "error":
 				fmt.Printf("Job %s failed\n", jobID)
 				if job.Debug != nil && job.Debug.Stderr != "" {
 					fmt.Printf("Error: %s\n", job.Debug.Stderr)
 				}
-				return
+				return fmt.Errorf("job %s failed", jobID)
 			case "killed":
 				fmt.Printf("Job %s was cancelled\n", jobID)
-				return
+				return fmt.Errorf("job %s was cancelled", jobID)
 			default:
 				if flags.Verbose {
 					fmt.Printf("Job %s status: %s\n", jobID, job.Status)
@@ -319,8 +251,6 @@ func handleQueryWait(ctx context.Context, client *td.Client, jobID string, flags
 }
 
 func printQueryResultsTable(results interface{}, limit int) {
-	// This is a simplified table printer for query results
-	// In a real implementation, you'd parse the JSON results properly
 	fmt.Printf("Query Results:\n")
 	fmt.Printf("%v\n", results)
 

--- a/cmd/tdcli/results.go
+++ b/cmd/tdcli/results.go
@@ -2,76 +2,28 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
-	"os"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-func handleResultCommands(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	if len(args) == 0 || args[0] == "help" {
-		printResultUsage()
-		return
-	}
-
-	subcommand := args[0]
-	subArgs := args[1:]
-
-	switch subcommand {
-	case "get", "show":
-		handleResultGet(ctx, client, subArgs, flags)
-	default:
-		fmt.Printf("Unknown result subcommand: %s\n", subcommand)
-		printResultUsage()
-		os.Exit(1)
-	}
-}
-
-func printResultUsage() {
-	fmt.Printf(`Result Management Commands
-
-USAGE:
-    tdcli results <subcommand> [options]
-    tdcli result <subcommand> [options]
-
-SUBCOMMANDS:
-    get, show <job_id>     Get query results
-
-OPTIONS:
-    --format FORMAT        Result format (json, csv, tsv, jsonl)
-    --limit LIMIT          Limit number of rows
-    --output FILE          Save results to file
-    --verbose, -v          Verbose output
-
-EXAMPLES:
-    tdcli result get 12345
-    tdcli result get 12345 --format csv
-    tdcli result get 12345 --limit 100 --output results.csv
-
-`)
-}
-
-func handleResultGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleResultGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: Job ID required")
-		fmt.Println("Usage: tdcli result get <job_id>")
-		os.Exit(1)
+		return errors.New("job ID required\nUsage: tdcli result get <job_id>")
 	}
 
 	jobIDStr := args[0]
 
-	// Set up result options
 	opts := &td.GetResultOptions{}
 
-	// Set format
 	format := flags.Format
 	if format == "" || format == "table" {
-		format = "json" // Default to JSON for API
+		format = "json"
 	}
 	opts.Format = td.ResultFormat(format)
 
-	// Set limit
 	if flags.Limit > 0 {
 		opts.Limit = flags.Limit
 	}
@@ -84,23 +36,26 @@ func handleResultGet(ctx context.Context, client *td.Client, args []string, flag
 		}
 	}
 
-	// Get results
 	resultReader, err := client.Results.GetResult(ctx, jobIDStr, opts)
-	handleError(err, "Failed to get results", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to get results", flags.Verbose)
+	}
 	defer resultReader.Close()
 
-	// Read all results
 	resultsBytes, err := io.ReadAll(resultReader)
-	handleError(err, "Failed to read results", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to read results", flags.Verbose)
+	}
 
 	results := string(resultsBytes)
 
-	// Output results
 	if flags.Output != "" {
-		err = writeOutput(results, flags.Output)
-		handleError(err, "Failed to write results to file", flags.Verbose)
+		if err := writeOutput(results, flags.Output); err != nil {
+			return wrapErr(err, "failed to write results to file", flags.Verbose)
+		}
 		fmt.Printf("Results saved to: %s\n", flags.Output)
 	} else {
 		fmt.Print(results)
 	}
+	return nil
 }

--- a/cmd/tdcli/stream_import.go
+++ b/cmd/tdcli/stream_import.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -10,11 +11,13 @@ import (
 
 const streamImportSizeWarningThreshold = 100 * 1024 * 1024 // 100 MB
 
-func handleStreamImport(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleStreamImport(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	if client == nil {
+		return errors.New("client is not initialized")
+	}
 	if len(args) < 3 {
-		fmt.Println("Usage: tdcli stream import <database> <table> <file-path> [unique-id]")
-		fmt.Println("Example: tdcli stream import mydb mytable data.msgpack.gz")
-		return
+		return errors.New("usage: tdcli stream import <database> <table> <file-path> [unique-id]\n" +
+			"Example: tdcli stream import mydb mytable data.msgpack.gz")
 	}
 
 	database := args[0]
@@ -27,8 +30,7 @@ func handleStreamImport(ctx context.Context, client *td.Client, args []string, f
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		handleError(err, "Failed to open import file", flags.Verbose)
-		return
+		return wrapErr(err, "failed to open import file", flags.Verbose)
 	}
 	defer file.Close()
 
@@ -46,12 +48,12 @@ func handleStreamImport(ctx context.Context, client *td.Client, args []string, f
 	}
 
 	if err != nil {
-		handleError(err, "Failed to import data", flags.Verbose)
-		return
+		return wrapErr(err, "failed to import data", flags.Verbose)
 	}
 
 	fmt.Printf("Import completed successfully\n")
 	if resp != nil && resp.Status != "" {
 		fmt.Printf("Status: %s\n", resp.Status)
 	}
+	return nil
 }

--- a/cmd/tdcli/tables.go
+++ b/cmd/tdcli/tables.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -9,67 +10,7 @@ import (
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-func handleTableCommands(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	if len(args) == 0 || args[0] == "help" {
-		printTableUsage()
-		return
-	}
-
-	subcommand := args[0]
-	subArgs := args[1:]
-
-	switch subcommand {
-	case "list", "ls":
-		handleTableList(ctx, client, subArgs, flags)
-	case "get", "show":
-		handleTableGet(ctx, client, subArgs, flags)
-	case "create":
-		handleTableCreate(ctx, client, subArgs, flags)
-	case "delete", "rm":
-		handleTableDelete(ctx, client, subArgs, flags)
-	case "swap":
-		handleTableSwap(ctx, client, subArgs, flags)
-	case "rename", "mv":
-		handleTableRename(ctx, client, subArgs, flags)
-	default:
-		fmt.Printf("Unknown table subcommand: %s\n", subcommand)
-		printTableUsage()
-		os.Exit(1)
-	}
-}
-
-func printTableUsage() {
-	fmt.Printf(`Table Management Commands
-
-USAGE:
-    tdcli tables <subcommand> [options]
-    tdcli table <subcommand> [options]
-
-SUBCOMMANDS:
-    list, ls <database>           List tables in database
-    get, show <database> <table>  Get table details
-    create <database> <table>     Create a new table
-    delete, rm <database> <table> Delete a table
-    swap <database> <table1> <table2>  Swap two tables
-    rename, mv <database> <from> <to>  Rename a table
-
-OPTIONS:
-    --database DATABASE   Database name (alternative to positional arg)
-    --format FORMAT       Output format (json, table, csv)
-    --verbose, -v         Verbose output
-
-EXAMPLES:
-    tdcli table list my_database
-    tdcli table show my_database my_table
-    tdcli table create my_database new_table
-    tdcli table delete my_database old_table
-    tdcli table swap my_database table1 table2
-    tdcli table rename my_database old_name new_name
-
-`)
-}
-
-func handleTableList(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleTableList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	var database string
 
 	if flags.Database != "" {
@@ -77,13 +18,13 @@ func handleTableList(ctx context.Context, client *td.Client, args []string, flag
 	} else if len(args) > 0 {
 		database = args[0]
 	} else {
-		fmt.Println("Error: Database name required")
-		fmt.Println("Usage: tdcli table list <database> OR tdcli table list --database <database>")
-		os.Exit(1)
+		return errors.New("database name required\nUsage: tdcli table list <database> OR tdcli table list --database <database>")
 	}
 
 	tables, err := client.Tables.List(ctx, database)
-	handleError(err, "Failed to list tables", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to list tables", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -93,20 +34,21 @@ func handleTableList(ctx context.Context, client *td.Client, args []string, flag
 	default:
 		printTablesTable(tables, database)
 	}
+	return nil
 }
 
-func handleTableGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleTableGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		fmt.Println("Error: Database and table names required")
-		fmt.Println("Usage: tdcli table get <database> <table>")
-		os.Exit(1)
+		return errors.New("database and table names required\nUsage: tdcli table get <database> <table>")
 	}
 
 	database := args[0]
 	tableName := args[1]
 
 	table, err := client.Tables.Get(ctx, database, tableName)
-	handleError(err, "Failed to get table", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to get table", flags.Verbose)
+	}
 
 	switch flags.Format {
 	case "json":
@@ -116,20 +58,21 @@ func handleTableGet(ctx context.Context, client *td.Client, args []string, flags
 	default:
 		printTableDetails(*table)
 	}
+	return nil
 }
 
-func handleTableCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleTableCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		fmt.Println("Error: Database and table names required")
-		fmt.Println("Usage: tdcli table create <database> <table>")
-		os.Exit(1)
+		return errors.New("database and table names required\nUsage: tdcli table create <database> <table>")
 	}
 
 	database := args[0]
 	tableName := args[1]
 
 	table, err := client.Tables.Create(ctx, database, tableName, "")
-	handleError(err, "Failed to create table", flags.Verbose)
+	if err != nil {
+		return wrapErr(err, "failed to create table", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully created table: %s.%s\n", database, table.Table)
@@ -141,50 +84,47 @@ func handleTableCreate(ctx context.Context, client *td.Client, args []string, fl
 	default:
 		fmt.Printf("Created table: %s.%s\n", database, table.Table)
 	}
+	return nil
 }
 
-func handleTableDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleTableDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		fmt.Println("Error: Database and table names required")
-		fmt.Println("Usage: tdcli table delete <database> <table>")
-		os.Exit(1)
+		return errors.New("database and table names required\nUsage: tdcli table delete <database> <table>")
 	}
 
 	database := args[0]
 	tableName := args[1]
 
-	// Confirm deletion
 	fmt.Printf("Are you sure you want to delete table '%s.%s'? (y/N): ", database, tableName)
 	var response string
 	fmt.Scanln(&response)
 
 	if response != "y" && response != "Y" && response != "yes" && response != "Yes" {
 		fmt.Println("Deletion cancelled")
-		return
+		return nil
 	}
 
-	err := client.Tables.Delete(ctx, database, tableName)
-	handleError(err, "Failed to delete table", flags.Verbose)
+	if err := client.Tables.Delete(ctx, database, tableName); err != nil {
+		return wrapErr(err, "failed to delete table", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully deleted table: %s.%s\n", database, tableName)
 	} else {
 		fmt.Printf("Deleted table: %s.%s\n", database, tableName)
 	}
+	return nil
 }
 
-func handleTableSwap(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleTableSwap(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		fmt.Println("Error: Database and two table names required")
-		fmt.Println("Usage: tdcli table swap <database> <table1> <table2>")
-		os.Exit(1)
+		return errors.New("database and two table names required\nUsage: tdcli table swap <database> <table1> <table2>")
 	}
 
 	database := args[0]
 	table1 := args[1]
 	table2 := args[2]
 
-	// Confirm swap
 	fmt.Printf("Are you sure you want to swap tables '%s.%s' and '%s.%s'? (y/N): ",
 		database, table1, database, table2)
 	var response string
@@ -192,11 +132,12 @@ func handleTableSwap(ctx context.Context, client *td.Client, args []string, flag
 
 	if response != "y" && response != "Y" && response != "yes" && response != "Yes" {
 		fmt.Println("Swap cancelled")
-		return
+		return nil
 	}
 
-	err := client.Tables.Swap(ctx, database, table1, table2)
-	handleError(err, "Failed to swap tables", flags.Verbose)
+	if err := client.Tables.Swap(ctx, database, table1, table2); err != nil {
+		return wrapErr(err, "failed to swap tables", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully initiated table swap: %s.%s <-> %s.%s\n",
@@ -205,20 +146,18 @@ func handleTableSwap(ctx context.Context, client *td.Client, args []string, flag
 		fmt.Printf("Swapped tables: %s.%s <-> %s.%s\n",
 			database, table1, database, table2)
 	}
+	return nil
 }
 
-func handleTableRename(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleTableRename(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		fmt.Println("Error: Database, old name, and new name required")
-		fmt.Println("Usage: tdcli table rename <database> <old_name> <new_name>")
-		os.Exit(1)
+		return errors.New("database, old name, and new name required\nUsage: tdcli table rename <database> <old_name> <new_name>")
 	}
 
 	database := args[0]
 	oldName := args[1]
 	newName := args[2]
 
-	// Confirm rename
 	fmt.Printf("Are you sure you want to rename table '%s.%s' to '%s.%s'? (y/N): ",
 		database, oldName, database, newName)
 	var response string
@@ -226,11 +165,12 @@ func handleTableRename(ctx context.Context, client *td.Client, args []string, fl
 
 	if response != "y" && response != "Y" && response != "yes" && response != "Yes" {
 		fmt.Println("Rename cancelled")
-		return
+		return nil
 	}
 
-	err := client.Tables.Rename(ctx, database, oldName, newName)
-	handleError(err, "Failed to rename table", flags.Verbose)
+	if err := client.Tables.Rename(ctx, database, oldName, newName); err != nil {
+		return wrapErr(err, "failed to rename table", flags.Verbose)
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Successfully renamed table: %s.%s -> %s.%s\n",
@@ -239,6 +179,7 @@ func handleTableRename(ctx context.Context, client *td.Client, args []string, fl
 		fmt.Printf("Renamed table: %s.%s -> %s.%s\n",
 			database, oldName, database, newName)
 	}
+	return nil
 }
 
 func printTablesTable(tables []td.Table, database string) {
@@ -275,7 +216,6 @@ func printTableDetails(table td.Table) {
 	fmt.Fprintf(w, "Created\t%s\n", formatTDTime(table.CreatedAt))
 	fmt.Fprintf(w, "Updated\t%s\n", formatTDTime(table.UpdatedAt))
 
-	// LastImport field doesn't exist in the current API
 	if table.LastLogTimestamp.Value != nil {
 		fmt.Fprintf(w, "Last Log\t%d\n", *table.LastLogTimestamp.Value)
 	}

--- a/cmd/tdcli/trino.go
+++ b/cmd/tdcli/trino.go
@@ -6,9 +6,9 @@ import (
 	"database/sql"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -23,12 +23,12 @@ import (
 )
 
 // handleTrinoQuery executes a Trino query and displays results
-func handleTrinoQuery(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleTrinoQuery(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if client == nil {
-		log.Fatal("Client is not initialized")
+		return errors.New("client is not initialized")
 	}
 	if len(args) == 0 {
-		log.Fatal("Query is required")
+		return errors.New("query is required")
 	}
 
 	query := args[0]
@@ -36,7 +36,6 @@ func handleTrinoQuery(ctx context.Context, client *td.Client, args []string, fla
 		fmt.Printf("Executing query: %s\n", query)
 	}
 
-	// Create Trino client using the SDK client's HTTP transport and OTEL config
 	trinoConfig := td.TDTrinoClientConfig{
 		APIKey:        flags.APIKey,
 		Region:        flags.Region,
@@ -50,59 +49,60 @@ func handleTrinoQuery(ctx context.Context, client *td.Client, args []string, fla
 
 	trinoClient, err := td.NewTDTrinoClient(trinoConfig)
 	if err != nil {
-		trinoClientError("create Trino client", err, flags)
+		return trinoClientError("create Trino client", err, flags)
 	}
 	defer trinoClient.Close()
 
-	// Execute query
 	start := time.Now()
 	rows, err := trinoClient.Query(ctx, query)
 	if err != nil {
-		enhanceTrinoQueryError("execute query", err, query, flags)
+		return enhanceTrinoQueryError("execute query", err, query, flags)
 	}
 	defer rows.Close()
 
-	// Get column info
 	columns, err := rows.Columns()
 	if err != nil {
-		log.Fatalf("Failed to get columns: %v", err)
+		return wrapErr(err, "failed to get columns", flags.Verbose)
 	}
 
-	// Prepare output
 	var output io.Writer = os.Stdout
 	if flags.Output != "" {
 		file, err := os.Create(flags.Output)
 		if err != nil {
-			log.Fatalf("Failed to create output file: %v", err)
+			return wrapErr(err, "failed to create output file", flags.Verbose)
 		}
 		defer file.Close()
 		output = file
 	}
 
-	// Format and display results
 	switch strings.ToLower(flags.Format) {
 	case "json":
-		handleTrinoQueryJSON(rows, columns, output, flags)
+		if err := handleTrinoQueryJSON(rows, columns, output, flags); err != nil {
+			return err
+		}
 	case "csv":
-		handleTrinoQueryCSV(rows, columns, output, flags)
+		if err := handleTrinoQueryCSV(rows, columns, output, flags); err != nil {
+			return err
+		}
 	case "table":
 		fallthrough
 	default:
-		handleTrinoQueryTable(rows, columns, output, flags)
+		if err := handleTrinoQueryTable(rows, columns, output, flags); err != nil {
+			return err
+		}
 	}
 
 	if flags.Verbose {
 		fmt.Printf("Query completed in %v\n", time.Since(start))
 	}
+	return nil
 }
 
 // handleTrinoQueryTable formats query results as a table
-func handleTrinoQueryTable(rows *sql.Rows, columns []string, output io.Writer, flags Flags) {
-	// Print header
+func handleTrinoQueryTable(rows *sql.Rows, columns []string, output io.Writer, flags Flags) error {
 	fmt.Fprint(output, strings.Join(columns, "\t"))
 	fmt.Fprintln(output)
 
-	// Print separator
 	for i, col := range columns {
 		if i > 0 {
 			fmt.Fprint(output, "\t")
@@ -111,26 +111,22 @@ func handleTrinoQueryTable(rows *sql.Rows, columns []string, output io.Writer, f
 	}
 	fmt.Fprintln(output)
 
-	// Print rows
 	rowCount := 0
 	for rows.Next() {
 		if flags.Limit > 0 && rowCount >= flags.Limit {
 			break
 		}
 
-		// Create slice to hold column values
 		values := make([]any, len(columns))
 		valuePtrs := make([]any, len(columns))
 		for i := range columns {
 			valuePtrs[i] = &values[i]
 		}
 
-		// Scan row
 		if err := rows.Scan(valuePtrs...); err != nil {
-			log.Fatalf("Failed to scan row: %v", err)
+			return wrapErr(err, "failed to scan row", flags.Verbose)
 		}
 
-		// Print values
 		for i, val := range values {
 			if i > 0 {
 				fmt.Fprint(output, "\t")
@@ -146,27 +142,25 @@ func handleTrinoQueryTable(rows *sql.Rows, columns []string, output io.Writer, f
 	}
 
 	if err := rows.Err(); err != nil {
-		log.Fatalf("Row iteration error: %v", err)
+		return wrapErr(err, "row iteration error", flags.Verbose)
 	}
 
 	if flags.Verbose {
 		fmt.Printf("Returned %d rows\n", rowCount)
 	}
+	return nil
 }
 
 // handleTrinoQueryTableWithPagination formats query results as a table with pagination support using buffered streaming
-func handleTrinoQueryTableWithPagination(rows *sql.Rows, columns []string, output io.Writer, pageSize int) int {
-	// Create buffered writer for more efficient output
+func handleTrinoQueryTableWithPagination(rows *sql.Rows, columns []string, output io.Writer, pageSize int) (int, error) {
 	var bufferedOutput *bufio.Writer
 	var isBuffered bool
 
-	// Check if output is already buffered or if it's stdout/stderr
 	if output == os.Stdout || output == os.Stderr {
-		bufferedOutput = bufio.NewWriterSize(output, 8192) // 8KB buffer
+		bufferedOutput = bufio.NewWriterSize(output, 8192)
 		isBuffered = true
 		defer bufferedOutput.Flush()
 	} else {
-		// For file outputs, create a buffered writer
 		bufferedOutput = bufio.NewWriterSize(output, 8192)
 		isBuffered = true
 		defer bufferedOutput.Flush()
@@ -177,11 +171,9 @@ func handleTrinoQueryTableWithPagination(rows *sql.Rows, columns []string, outpu
 		actualOutput = output
 	}
 
-	// Print header
 	fmt.Fprint(actualOutput, strings.Join(columns, "\t"))
 	fmt.Fprintln(actualOutput)
 
-	// Print separator
 	for i, col := range columns {
 		if i > 0 {
 			fmt.Fprint(actualOutput, "\t")
@@ -190,7 +182,6 @@ func handleTrinoQueryTableWithPagination(rows *sql.Rows, columns []string, outpu
 	}
 	fmt.Fprintln(actualOutput)
 
-	// Flush header immediately for better UX
 	if isBuffered {
 		bufferedOutput.Flush()
 	}
@@ -199,24 +190,20 @@ func handleTrinoQueryTableWithPagination(rows *sql.Rows, columns []string, outpu
 	pageRows := 0
 	scanner := bufio.NewScanner(os.Stdin)
 
-	// Pre-allocate buffers for row building
 	var rowBuilder strings.Builder
-	rowBuilder.Grow(1024) // Pre-allocate 1KB for typical row
+	rowBuilder.Grow(1024)
 
 	for rows.Next() {
-		// Create slice to hold column values
 		values := make([]any, len(columns))
 		valuePtrs := make([]any, len(columns))
 		for i := range columns {
 			valuePtrs[i] = &values[i]
 		}
 
-		// Scan row
 		if err := rows.Scan(valuePtrs...); err != nil {
-			log.Fatalf("Failed to scan row: %v", err)
+			return totalRows, fmt.Errorf("failed to scan row: %w", err)
 		}
 
-		// Build row string efficiently using string builder
 		rowBuilder.Reset()
 		for i, val := range values {
 			if i > 0 {
@@ -230,15 +217,12 @@ func handleTrinoQueryTableWithPagination(rows *sql.Rows, columns []string, outpu
 		}
 		rowBuilder.WriteString("\n")
 
-		// Write the complete row in one operation
 		actualOutput.Write([]byte(rowBuilder.String()))
 
 		totalRows++
 		pageRows++
 
-		// Check if we need to paginate (only if pageSize > 0)
 		if pageSize > 0 && pageRows >= pageSize {
-			// Flush current page before showing pagination prompt
 			if isBuffered {
 				bufferedOutput.Flush()
 			}
@@ -251,35 +235,31 @@ func handleTrinoQueryTableWithPagination(rows *sql.Rows, columns []string, outpu
 				switch input {
 				case "q", "quit":
 					fmt.Printf("Query stopped. Showed %d of potentially more rows.\n", totalRows)
-					return totalRows
+					return totalRows, nil
 				case "a", "all":
-					// Continue without pagination
-					pageSize = 0 // Disable pagination
+					pageSize = 0
 				}
 			}
-			pageRows = 0 // Reset page counter
+			pageRows = 0
 		}
 
-		// Periodic flush for better responsiveness (every 10 rows when not paginating)
 		if pageSize == 0 && totalRows%10 == 0 && isBuffered {
 			bufferedOutput.Flush()
 		}
 	}
 
 	if err := rows.Err(); err != nil {
-		log.Fatalf("Row iteration error: %v", err)
+		return totalRows, fmt.Errorf("row iteration error: %w", err)
 	}
 
-	return totalRows
+	return totalRows, nil
 }
 
 // handleTrinoQueryJSON formats query results as streaming JSON array
-func handleTrinoQueryJSON(rows *sql.Rows, columns []string, output io.Writer, flags Flags) {
-	// Create buffered writer for efficient streaming
+func handleTrinoQueryJSON(rows *sql.Rows, columns []string, output io.Writer, flags Flags) error {
 	bufferedOutput := bufio.NewWriterSize(output, 8192)
 	defer bufferedOutput.Flush()
 
-	// Start JSON array
 	bufferedOutput.WriteString("[\n")
 
 	rowCount := 0
@@ -290,22 +270,18 @@ func handleTrinoQueryJSON(rows *sql.Rows, columns []string, output io.Writer, fl
 			break
 		}
 
-		// Create slice to hold column values
 		values := make([]any, len(columns))
 		valuePtrs := make([]any, len(columns))
 		for i := range columns {
 			valuePtrs[i] = &values[i]
 		}
 
-		// Scan row
 		if err := rows.Scan(valuePtrs...); err != nil {
-			log.Fatalf("Failed to scan row: %v", err)
+			return wrapErr(err, "failed to scan row", flags.Verbose)
 		}
 
-		// Create result map
 		result := make(map[string]any)
 		for i, col := range columns {
-			// Convert []byte to string for JSON marshaling
 			if bytes, ok := values[i].([]byte); ok {
 				result[col] = string(bytes)
 			} else {
@@ -313,17 +289,15 @@ func handleTrinoQueryJSON(rows *sql.Rows, columns []string, output io.Writer, fl
 			}
 		}
 
-		// Add comma separator for subsequent rows
 		if !firstRow {
 			bufferedOutput.WriteString(",\n")
 		} else {
 			firstRow = false
 		}
 
-		// Marshal and stream each row immediately as JSON
 		jsonBytes, err := json.MarshalIndent(result, "  ", "  ")
 		if err != nil {
-			log.Fatalf("Failed to encode JSON row: %v", err)
+			return wrapErr(err, "failed to encode JSON row", flags.Verbose)
 		}
 
 		bufferedOutput.WriteString("  ")
@@ -331,64 +305,56 @@ func handleTrinoQueryJSON(rows *sql.Rows, columns []string, output io.Writer, fl
 
 		rowCount++
 
-		// Periodic flush for responsiveness (every 100 rows)
 		if rowCount%100 == 0 {
 			bufferedOutput.Flush()
 		}
 	}
 
 	if err := rows.Err(); err != nil {
-		log.Fatalf("Row iteration error: %v", err)
+		return wrapErr(err, "row iteration error", flags.Verbose)
 	}
 
-	// Close JSON array
 	bufferedOutput.WriteString("\n]\n")
 	bufferedOutput.Flush()
 
 	if flags.Verbose {
 		fmt.Printf("Returned %d rows\n", rowCount)
 	}
+	return nil
 }
 
 // handleTrinoQueryCSV formats query results as streaming CSV
-func handleTrinoQueryCSV(rows *sql.Rows, columns []string, output io.Writer, flags Flags) {
-	// Create buffered writer for efficient streaming
+func handleTrinoQueryCSV(rows *sql.Rows, columns []string, output io.Writer, flags Flags) error {
 	bufferedOutput := bufio.NewWriterSize(output, 8192)
 	defer bufferedOutput.Flush()
 
 	writer := csv.NewWriter(bufferedOutput)
 	defer writer.Flush()
 
-	// Write header immediately
 	if err := writer.Write(columns); err != nil {
-		log.Fatalf("Failed to write CSV header: %v", err)
+		return wrapErr(err, "failed to write CSV header", flags.Verbose)
 	}
-	writer.Flush()         // Flush header immediately
-	bufferedOutput.Flush() // Ensure header is visible
+	writer.Flush()
+	bufferedOutput.Flush()
 
-	// Pre-allocate string slice for better performance
 	record := make([]string, len(columns))
 
-	// Write rows
 	rowCount := 0
 	for rows.Next() {
 		if flags.Limit > 0 && rowCount >= flags.Limit {
 			break
 		}
 
-		// Create slice to hold column values
 		values := make([]any, len(columns))
 		valuePtrs := make([]any, len(columns))
 		for i := range columns {
 			valuePtrs[i] = &values[i]
 		}
 
-		// Scan row
 		if err := rows.Scan(valuePtrs...); err != nil {
-			log.Fatalf("Failed to scan row: %v", err)
+			return wrapErr(err, "failed to scan row", flags.Verbose)
 		}
 
-		// Convert to string slice (reuse slice)
 		for i, val := range values {
 			if val == nil {
 				record[i] = ""
@@ -398,11 +364,10 @@ func handleTrinoQueryCSV(rows *sql.Rows, columns []string, output io.Writer, fla
 		}
 
 		if err := writer.Write(record); err != nil {
-			log.Fatalf("Failed to write CSV record: %v", err)
+			return wrapErr(err, "failed to write CSV record", flags.Verbose)
 		}
 		rowCount++
 
-		// Periodic flush for responsiveness (every 100 rows)
 		if rowCount%100 == 0 {
 			writer.Flush()
 			bufferedOutput.Flush()
@@ -410,22 +375,22 @@ func handleTrinoQueryCSV(rows *sql.Rows, columns []string, output io.Writer, fla
 	}
 
 	if err := rows.Err(); err != nil {
-		log.Fatalf("Row iteration error: %v", err)
+		return wrapErr(err, "row iteration error", flags.Verbose)
 	}
 
 	if flags.Verbose {
 		fmt.Printf("Returned %d rows\n", rowCount)
 	}
+	return nil
 }
 
 // handleTrinoTest tests the Trino connection
-func handleTrinoTest(ctx context.Context, client *td.Client, _ []string, flags Flags) {
+func handleTrinoTest(ctx context.Context, client *td.Client, _ []string, flags Flags) error {
 	if client == nil {
-		log.Fatal("Client is not initialized")
+		return errors.New("client is not initialized")
 	}
 	fmt.Println("Testing Trino connection...")
 
-	// Create Trino client using the SDK client's HTTP transport and OTEL config
 	trinoConfig := td.TDTrinoClientConfig{
 		APIKey:        flags.APIKey,
 		Region:        flags.Region,
@@ -439,7 +404,6 @@ func handleTrinoTest(ctx context.Context, client *td.Client, _ []string, flags F
 
 	trinoClient, err := td.NewTDTrinoClient(trinoConfig)
 	if err != nil {
-		// Enhanced error message for client creation failure
 		fmt.Printf("❌ Failed to create Trino client\n")
 		fmt.Printf("Error: %v\n\n", err)
 		fmt.Printf("Troubleshooting tips:\n")
@@ -447,14 +411,12 @@ func handleTrinoTest(ctx context.Context, client *td.Client, _ []string, flags F
 		fmt.Printf("• Verify the region is valid: %s\n", flags.Region)
 		fmt.Printf("• Ensure you have network connectivity\n")
 		fmt.Printf("• Try with --verbose for more details\n")
-		log.Fatal("")
+		return fmt.Errorf("failed to create Trino client: %w", err)
 	}
 	defer trinoClient.Close()
 
-	// Test connection with a simple query
 	start := time.Now()
 	if err := trinoClient.Ping(ctx); err != nil {
-		// Enhanced error message for connection failure
 		fmt.Printf("❌ Connection test failed\n")
 		fmt.Printf("Error: %v\n\n", err)
 		fmt.Printf("Troubleshooting tips:\n")
@@ -463,19 +425,20 @@ func handleTrinoTest(ctx context.Context, client *td.Client, _ []string, flags F
 		fmt.Printf("• Confirm the region '%s' is correct for your account\n", flags.Region)
 		fmt.Printf("• Try a different database with --database flag\n")
 		fmt.Printf("• Check firewall/proxy settings if in corporate network\n")
-		log.Fatal("")
+		return fmt.Errorf("connection test failed: %w", err)
 	}
 
 	fmt.Printf("✅ Connection successful (took %v)\n", time.Since(start))
 	fmt.Printf("Region: %s\n", flags.Region)
 	fmt.Printf("Database: %s\n", flags.Database)
 	fmt.Printf("Endpoint: %s\n", trinoClient.GetEndpoint())
+	return nil
 }
 
 // handleTrinoInteractive starts an enhanced interactive Trino session with history and auto-completion
-func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, flags Flags) {
+func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, flags Flags) error {
 	if client == nil {
-		log.Fatal("Client is not initialized")
+		return errors.New("client is not initialized")
 	}
 	currentDatabase := flags.Database
 
@@ -484,7 +447,6 @@ func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, 
 	fmt.Printf("Database: %s, Region: %s\n", currentDatabase, flags.Region)
 	fmt.Println()
 
-	// Create initial Trino client using the SDK client's HTTP transport and OTEL config
 	trinoConfig := td.TDTrinoClientConfig{
 		APIKey:        flags.APIKey,
 		Region:        flags.Region,
@@ -504,32 +466,27 @@ func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, 
 		fmt.Printf("  • API key: %s\n", flags.APIKey[:10]+"...")
 		fmt.Printf("  • Region: %s\n", flags.Region)
 		fmt.Printf("  • Database: %s\n", currentDatabase)
-		log.Fatal("")
+		return fmt.Errorf("failed to create Trino client: %w", err)
 	}
 	defer trinoClient.Close()
 
-	// Test connection
 	if err := trinoClient.Ping(ctx); err != nil {
 		fmt.Printf("❌ Connection test failed for interactive session\n")
 		fmt.Printf("Error: %v\n\n", err)
 		fmt.Printf("💡 This may indicate network issues or permission problems\n")
 		fmt.Printf("  • Try: tdcli trino test --region %s --database %s\n", flags.Region, currentDatabase)
 		fmt.Printf("  • Check your network connectivity\n")
-		log.Fatal("")
+		return fmt.Errorf("connection test failed: %w", err)
 	}
 
-	// Create context for cancellation
 	interactiveCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Set up signal handling for Ctrl+C during queries
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
-	// Create autocompletion system
 	autoCompleter := newTrinoAutoCompleter(trinoClient, &currentDatabase)
 
-	// Setup readline with history and auto-completion
 	historyFile := getHistoryFile()
 	rl, err := readline.NewEx(&readline.Config{
 		Prompt:            fmt.Sprintf("trino:%s> ", currentDatabase),
@@ -541,27 +498,25 @@ func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, 
 		HistorySearchFold: true,
 	})
 	if err != nil {
-		log.Fatalf("Failed to create readline: %v", err)
+		return wrapErr(err, "failed to create readline", flags.Verbose)
 	}
 	defer rl.Close()
 
 	for {
-		// Update prompt with current database
 		rl.SetPrompt(fmt.Sprintf("trino:%s> ", currentDatabase))
 
 		line, err := rl.Readline()
 		if err == readline.ErrInterrupt {
 			if len(line) == 0 {
 				fmt.Println("\nGoodbye!")
-				return
-			} else {
-				continue
+				return nil
 			}
+			continue
 		} else if err == io.EOF {
 			fmt.Println("\nGoodbye!")
-			return
+			return nil
 		} else if err != nil {
-			log.Fatalf("Readline error: %v", err)
+			return wrapErr(err, "readline error", flags.Verbose)
 		}
 
 		input := strings.TrimSpace(line)
@@ -569,12 +524,11 @@ func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, 
 			continue
 		}
 
-		// Handle special commands
 		lowerInput := strings.ToLower(input)
 		switch {
 		case lowerInput == "quit" || lowerInput == "exit":
 			fmt.Println("Goodbye!")
-			return
+			return nil
 		case lowerInput == "help":
 			printTrinoHelp()
 			continue
@@ -586,9 +540,8 @@ func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, 
 		case lowerInput == "show tables":
 			input = "SHOW TABLES"
 		case strings.HasPrefix(lowerInput, "use "):
-			// Handle database switching with robust error recovery
-			newDB := strings.TrimSpace(input[4:]) // Remove "use "
-			newDB = strings.Trim(newDB, `"'`)     // Remove quotes if present
+			newDB := strings.TrimSpace(input[4:])
+			newDB = strings.Trim(newDB, `"'`)
 
 			if newDB == "" {
 				fmt.Println("❌ Error: Database name required. Usage: USE database_name")
@@ -606,21 +559,17 @@ func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, 
 			fmt.Printf("Current database: %s\n", currentDatabase)
 			continue
 		case strings.HasPrefix(lowerInput, "show tables from "):
-			// Extract database name and show tables
-			dbName := strings.TrimSpace(input[17:]) // Remove "show tables from "
-			dbName = strings.Trim(dbName, `"'`)     // Remove quotes
+			dbName := strings.TrimSpace(input[17:])
+			dbName = strings.Trim(dbName, `"'`)
 			input = fmt.Sprintf("SHOW TABLES FROM %s", td.EscapeIdentifier(dbName))
 		case strings.HasPrefix(lowerInput, "describe "):
-			// Enhance describe to work with current database context
-			tableName := strings.TrimSpace(input[9:]) // Remove "describe "
+			tableName := strings.TrimSpace(input[9:])
 			if !strings.Contains(tableName, ".") {
-				// If no database specified, use current database
 				tableName = fmt.Sprintf("%s.%s", td.EscapeIdentifier(currentDatabase), td.EscapeIdentifier(tableName))
 			}
 			input = fmt.Sprintf("DESCRIBE %s", tableName)
 		}
 
-		// Execute query with cancellation support
 		queryCtx, queryCancel := context.WithCancel(interactiveCtx)
 		var queryDone = make(chan struct{})
 		var queryErr error
@@ -629,7 +578,6 @@ func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, 
 		var rowCount int
 		start := time.Now()
 
-		// Start query in goroutine
 		go func() {
 			defer close(queryDone)
 			rows, queryErr = trinoClient.Query(queryCtx, input)
@@ -637,19 +585,16 @@ func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, 
 				return
 			}
 
-			// Get columns
 			columns, queryErr = rows.Columns()
 			if queryErr != nil {
 				rows.Close()
 				return
 			}
 
-			// Display results in table format with pagination
-			rowCount = handleTrinoQueryTableWithPagination(rows, columns, os.Stdout, 20) // 20 rows per page
+			rowCount, queryErr = handleTrinoQueryTableWithPagination(rows, columns, os.Stdout, 20)
 			rows.Close()
 		}()
 
-		// Wait for either query completion or cancellation signal
 		select {
 		case <-queryDone:
 			queryCancel()
@@ -661,7 +606,6 @@ func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, 
 		case sig := <-sigChan:
 			fmt.Printf("\n\nReceived signal %v, cancelling query...\n", sig)
 			queryCancel()
-			// Wait for query to actually cancel
 			<-queryDone
 			fmt.Printf("Query cancelled after %v\n\n", time.Since(start))
 		}
@@ -672,11 +616,9 @@ func handleTrinoInteractive(ctx context.Context, client *td.Client, _ []string, 
 func getHistoryFile() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		// Fallback to temp directory
 		return filepath.Join(os.TempDir(), ".tdcli_trino_history")
 	}
 
-	// Create .tdcli directory if it doesn't exist
 	configDir := filepath.Join(homeDir, ".tdcli")
 	os.MkdirAll(configDir, 0755)
 
@@ -688,11 +630,10 @@ type trinoAutoCompleter struct {
 	client     *td.TDTrinoClient
 	database   *string
 	keywords   []string
-	tables     map[string][]string // database -> tables
+	tables     map[string][]string
 	tableCache time.Time
 }
 
-// newTrinoAutoCompleter creates a new auto-completer
 func newTrinoAutoCompleter(client *td.TDTrinoClient, database *string) *trinoAutoCompleter {
 	keywords := []string{
 		"SELECT", "FROM", "WHERE", "GROUP", "BY", "ORDER", "HAVING", "LIMIT",
@@ -712,7 +653,6 @@ func newTrinoAutoCompleter(client *td.TDTrinoClient, database *string) *trinoAut
 	}
 }
 
-// Do implements readline.AutoCompleter interface
 func (t *trinoAutoCompleter) Do(line []rune, pos int) (newLine [][]rune, length int) {
 	lineStr := string(line)
 	currentWord := t.getCurrentWord(lineStr, pos)
@@ -726,7 +666,6 @@ func (t *trinoAutoCompleter) Do(line []rune, pos int) (newLine [][]rune, length 
 		return nil, 0
 	}
 
-	// Convert suggestions to [][]rune
 	result := make([][]rune, len(suggestions))
 	for i, suggestion := range suggestions {
 		result[i] = []rune(suggestion)
@@ -735,18 +674,15 @@ func (t *trinoAutoCompleter) Do(line []rune, pos int) (newLine [][]rune, length 
 	return result, len(currentWord)
 }
 
-// getCurrentWord extracts the current word being typed
 func (t *trinoAutoCompleter) getCurrentWord(line string, pos int) string {
 	if pos <= 0 || pos > len(line) {
 		return ""
 	}
 
-	// If we're at a whitespace, return empty
 	if pos <= len(line) && (pos == len(line) || !isWordChar(rune(line[pos-1]))) {
 		return ""
 	}
 
-	// Find word boundaries
 	start := pos - 1
 	for start > 0 && isWordChar(rune(line[start-1])) {
 		start--
@@ -764,14 +700,11 @@ func (t *trinoAutoCompleter) getCurrentWord(line string, pos int) string {
 	return line[start:end]
 }
 
-// isWordChar checks if a character is part of a word
 func isWordChar(r rune) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
 }
 
-// getSuggestions returns completion suggestions
 func (t *trinoAutoCompleter) getSuggestions(word, line string) []string {
-	// Return empty if no word to complete
 	if word == "" {
 		return []string{}
 	}
@@ -779,49 +712,40 @@ func (t *trinoAutoCompleter) getSuggestions(word, line string) []string {
 	word = strings.ToUpper(word)
 	var suggestions []string
 
-	// SQL keywords
 	for _, keyword := range t.keywords {
 		if strings.HasPrefix(keyword, word) {
 			suggestions = append(suggestions, keyword)
 		}
 	}
 
-	// Table names if we're in a FROM context
 	if t.isFromContext(line) {
 		tables := t.getTableSuggestions(word)
 		suggestions = append(suggestions, tables...)
 	}
 
-	// Database names if we're in a USE context
 	if t.isUseContext(line) {
 		databases := t.getDatabaseSuggestions(word)
 		suggestions = append(suggestions, databases...)
 	}
 
-	// Sort suggestions
 	sort.Strings(suggestions)
 
-	// Remove duplicates
 	return removeDuplicates(suggestions)
 }
 
-// isFromContext checks if we're in a FROM clause context
 func (t *trinoAutoCompleter) isFromContext(line string) bool {
 	line = strings.ToUpper(line)
 	fromRegex := regexp.MustCompile(`\bFROM\s+\w*$`)
 	return fromRegex.MatchString(line)
 }
 
-// isUseContext checks if we're in a USE statement context
 func (t *trinoAutoCompleter) isUseContext(line string) bool {
 	line = strings.ToUpper(line)
 	useRegex := regexp.MustCompile(`^\s*USE\s+\w*$`)
 	return useRegex.MatchString(line)
 }
 
-// getTableSuggestions returns table name suggestions
 func (t *trinoAutoCompleter) getTableSuggestions(word string) []string {
-	// Refresh cache if needed (every 30 seconds)
 	if time.Since(t.tableCache) > 30*time.Second {
 		t.refreshTableCache()
 	}
@@ -829,7 +753,6 @@ func (t *trinoAutoCompleter) getTableSuggestions(word string) []string {
 	var suggestions []string
 	word = strings.ToUpper(word)
 
-	// Get tables from current database
 	if t.database != nil {
 		if tables, exists := t.tables[*t.database]; exists {
 			for _, table := range tables {
@@ -843,12 +766,10 @@ func (t *trinoAutoCompleter) getTableSuggestions(word string) []string {
 	return suggestions
 }
 
-// getDatabaseSuggestions returns database name suggestions
 func (t *trinoAutoCompleter) getDatabaseSuggestions(word string) []string {
 	var suggestions []string
 	word = strings.ToUpper(word)
 
-	// Get database names
 	databases := t.getDatabases()
 	for _, db := range databases {
 		if strings.HasPrefix(strings.ToUpper(db), word) {
@@ -859,7 +780,6 @@ func (t *trinoAutoCompleter) getDatabaseSuggestions(word string) []string {
 	return suggestions
 }
 
-// refreshTableCache refreshes the table cache
 func (t *trinoAutoCompleter) refreshTableCache() {
 	if t.database == nil {
 		return
@@ -871,7 +791,7 @@ func (t *trinoAutoCompleter) refreshTableCache() {
 	query := fmt.Sprintf("SHOW TABLES FROM %s", td.EscapeIdentifier(*t.database))
 	rows, err := t.client.Query(ctx, query)
 	if err != nil {
-		return // Silently fail to avoid disrupting user experience
+		return
 	}
 	defer rows.Close()
 
@@ -888,14 +808,13 @@ func (t *trinoAutoCompleter) refreshTableCache() {
 	t.tableCache = time.Now()
 }
 
-// getDatabases returns list of available databases
 func (t *trinoAutoCompleter) getDatabases() []string {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	rows, err := t.client.Query(ctx, "SHOW SCHEMAS")
 	if err != nil {
-		return nil // Silently fail
+		return nil
 	}
 	defer rows.Close()
 
@@ -911,14 +830,11 @@ func (t *trinoAutoCompleter) getDatabases() []string {
 	return databases
 }
 
-// updateDatabase updates the current database for auto-completion
 func (t *trinoAutoCompleter) updateDatabase(database *string) {
 	t.database = database
-	// Clear table cache to force refresh
 	t.tableCache = time.Time{}
 }
 
-// removeDuplicates removes duplicate strings from a slice
 func removeDuplicates(slice []string) []string {
 	seen := make(map[string]bool)
 	result := []string{}
@@ -933,12 +849,11 @@ func removeDuplicates(slice []string) []string {
 	return result
 }
 
-// TrinoClientError provides detailed error messages for client creation failures
-func trinoClientError(operation string, err error, flags Flags) {
+// trinoClientError formats a detailed Trino client creation failure as an error.
+func trinoClientError(operation string, err error, flags Flags) error {
 	fmt.Printf("❌ Failed to %s\n", operation)
 	fmt.Printf("Error: %v\n\n", err)
 
-	// Check for common error patterns
 	errStr := strings.ToLower(err.Error())
 
 	fmt.Printf("💡 Troubleshooting tips:\n")
@@ -971,25 +886,20 @@ func trinoClientError(operation string, err error, flags Flags) {
 	fmt.Printf("  Region: %s\n", flags.Region)
 	fmt.Printf("  Database: %s\n", flags.Database)
 
-	if captureHandlerErrors {
-		panic(fmt.Errorf("failed to %s: %v", operation, err))
-	}
-	log.Fatal("")
+	return fmt.Errorf("failed to %s: %w", operation, err)
 }
 
-// enhanceTrinoQueryError provides detailed error messages for query execution failures
-func enhanceTrinoQueryError(operation string, err error, query string, flags Flags) {
+// enhanceTrinoQueryError formats a detailed Trino query failure as an error.
+func enhanceTrinoQueryError(operation string, err error, query string, flags Flags) error {
 	fmt.Printf("❌ Failed to %s\n", operation)
 	fmt.Printf("Error: %v\n", err)
 
-	// Show truncated query for context (first 100 chars)
 	truncatedQuery := query
 	if len(query) > 100 {
 		truncatedQuery = query[:100] + "..."
 	}
 	fmt.Printf("Query: %s\n\n", truncatedQuery)
 
-	// Check for common SQL error patterns
 	errStr := strings.ToLower(err.Error())
 
 	fmt.Printf("💡 Troubleshooting tips:\n")
@@ -1029,13 +939,11 @@ func enhanceTrinoQueryError(operation string, err error, query string, flags Fla
 		fmt.Printf("  • Use --verbose flag for more detailed error information\n")
 	}
 
-	if captureHandlerErrors {
-		panic(fmt.Errorf("failed to %s: %v", operation, err))
-	}
-	log.Fatal("")
+	return fmt.Errorf("failed to %s: %w", operation, err)
 }
 
-// switchDatabase handles robust database switching with comprehensive error recovery
+// switchDatabase handles robust database switching with comprehensive error recovery.
+// Returns true on success; on failure prints diagnostics and restores the previous DB.
 func switchDatabase(trinoClient **td.TDTrinoClient, config *td.TDTrinoClientConfig,
 	currentDB *string, newDB string, completer *trinoAutoCompleter, ctx context.Context) bool {
 
@@ -1043,7 +951,6 @@ func switchDatabase(trinoClient **td.TDTrinoClient, config *td.TDTrinoClientConf
 
 	fmt.Printf("🔄 Switching to database '%s'...\\n", newDB)
 
-	// Step 1: Validate database exists by trying to access it
 	testQuery := fmt.Sprintf("SHOW TABLES FROM %s LIMIT 1", td.EscapeIdentifier(newDB))
 	testRows, testErr := (*trinoClient).Query(ctx, testQuery)
 	if testErr != nil {
@@ -1058,17 +965,14 @@ func switchDatabase(trinoClient **td.TDTrinoClient, config *td.TDTrinoClientConf
 	}
 	testRows.Close()
 
-	// Step 2: Close current connection
 	(*trinoClient).Close()
 
-	// Step 3: Create new client with target database
 	config.Database = newDB
 	newClient, err := td.NewTDTrinoClient(*config)
 	if err != nil {
 		fmt.Printf("❌ Failed to create connection to database '%s'\\n", newDB)
 		fmt.Printf("Error: %v\\n\\n", err)
 
-		// Step 4: Recovery - restore original database connection
 		fmt.Printf("🔄 Recovering connection to original database '%s'...\\n", originalDB)
 		config.Database = originalDB
 		recoveredClient, recoverErr := td.NewTDTrinoClient(*config)
@@ -1079,7 +983,9 @@ func switchDatabase(trinoClient **td.TDTrinoClient, config *td.TDTrinoClientConf
 			fmt.Printf("  • Restart the interactive session\\n")
 			fmt.Printf("  • Check your network connection\\n")
 			fmt.Printf("  • Verify API key is still valid\\n")
-			log.Fatal("Interactive session corrupted, exiting")
+			// Connection lost beyond repair; surface to caller as a fatal error.
+			fmt.Println("Interactive session corrupted, exiting")
+			os.Exit(1)
 		}
 
 		*trinoClient = recoveredClient
@@ -1088,12 +994,10 @@ func switchDatabase(trinoClient **td.TDTrinoClient, config *td.TDTrinoClientConf
 		return false
 	}
 
-	// Step 5: Final validation of new connection
 	if pingErr := newClient.Ping(ctx); pingErr != nil {
 		fmt.Printf("❌ Connection to database '%s' created but ping failed\\n", newDB)
 		fmt.Printf("Ping Error: %v\\n\\n", pingErr)
 
-		// Step 6: Recovery - close failed connection and restore original
 		newClient.Close()
 		fmt.Printf("🔄 Recovering connection to original database '%s'...\\n", originalDB)
 		config.Database = originalDB
@@ -1101,7 +1005,8 @@ func switchDatabase(trinoClient **td.TDTrinoClient, config *td.TDTrinoClientConf
 		if recoverErr != nil {
 			fmt.Printf("❌ Critical: Failed to recover connection to original database '%s'\\n", originalDB)
 			fmt.Printf("Recovery Error: %v\\n", recoverErr)
-			log.Fatal("Interactive session corrupted, exiting")
+			fmt.Println("Interactive session corrupted, exiting")
+			os.Exit(1)
 		}
 
 		*trinoClient = recoveredClient
@@ -1110,7 +1015,6 @@ func switchDatabase(trinoClient **td.TDTrinoClient, config *td.TDTrinoClientConf
 		return false
 	}
 
-	// Step 7: Success - update all references
 	*trinoClient = newClient
 	*currentDB = newDB
 	completer.updateDatabase(currentDB)
@@ -1125,7 +1029,7 @@ Interactive Trino Commands:
   quit, exit               - Exit the interactive session
   help                     - Show this help message
   clear, cls               - Clear the screen
-  
+
 Database Commands:
   show databases           - List all available databases
   show schemas             - Same as show databases
@@ -1133,7 +1037,7 @@ Database Commands:
   show current database    - Show the current database name
   show tables              - List tables in current database
   show tables from <db>    - List tables in specified database
-  
+
 SQL Commands:
   SELECT ...               - Execute SELECT queries
   DESCRIBE <table>         - Show table structure (uses current database)
@@ -1141,14 +1045,14 @@ SQL Commands:
   SHOW SCHEMAS             - List all schemas/databases
   SHOW TABLES              - List tables in current schema
   SHOW TABLES FROM <db>    - List tables from specific database
-  
+
 Enhanced Features:
   Command History          - Use Up/Down arrows to navigate command history
   Auto-completion          - Press Tab for SQL keyword and table name completion
   Query Cancellation       - Press Ctrl+C to cancel running queries
   Error Recovery           - Automatic recovery from database switching failures
   Smart Error Messages     - Context-aware troubleshooting tips for common issues
-  
+
 Keyboard Shortcuts:
   Tab                      - Auto-complete current word
   Up/Down Arrow            - Navigate command history
@@ -1158,7 +1062,7 @@ Keyboard Shortcuts:
   Ctrl+U                   - Delete from cursor to beginning of line
   Ctrl+C                   - Cancel current query (during execution)
   Ctrl+C (empty line)      - Exit interactive session
-  
+
 Pagination Controls (for large result sets):
   Enter             - Show next page
   q, quit           - Stop query and exit pagination
@@ -1175,25 +1079,23 @@ Examples:
 }
 
 // handleTrinoDescribe describes a table structure
-func handleTrinoDescribe(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleTrinoDescribe(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		log.Fatal("Table name is required")
+		return errors.New("table name is required")
 	}
 
 	tableName := args[0]
 
-	// Escape table name for safety
 	escapedTable := td.EscapeIdentifier(tableName)
 	query := fmt.Sprintf("DESCRIBE %s", escapedTable)
 
-	// Execute as a regular query
-	handleTrinoQuery(ctx, client, []string{query}, flags)
+	return handleTrinoQuery(ctx, client, []string{query}, flags)
 }
 
 // handleTrinoShow executes SHOW commands
-func handleTrinoShow(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleTrinoShow(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		log.Fatal("SHOW command type required (schemas, tables, columns)")
+		return errors.New("SHOW command type required (schemas, tables, columns)")
 	}
 
 	showType := strings.ToLower(args[0])
@@ -1210,37 +1112,35 @@ func handleTrinoShow(ctx context.Context, client *td.Client, args []string, flag
 		}
 	case "columns":
 		if len(args) < 2 {
-			log.Fatal("Table name required for SHOW COLUMNS")
+			return errors.New("table name required for SHOW COLUMNS")
 		}
 		tableName := td.EscapeIdentifier(args[1])
 		query = fmt.Sprintf("SHOW COLUMNS FROM %s", tableName)
 	default:
-		log.Fatalf("Unknown SHOW command: %s", showType)
+		return fmt.Errorf("unknown SHOW command: %s", showType)
 	}
 
-	// Execute as a regular query
-	handleTrinoQuery(ctx, client, []string{query}, flags)
+	return handleTrinoQuery(ctx, client, []string{query}, flags)
 }
 
 // handleTrinoExplain explains a query execution plan
-func handleTrinoExplain(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleTrinoExplain(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		log.Fatal("Query is required for EXPLAIN")
+		return errors.New("query is required for EXPLAIN")
 	}
 
 	query := fmt.Sprintf("EXPLAIN %s", args[0])
 
-	// Execute as a regular query
-	handleTrinoQuery(ctx, client, []string{query}, flags)
+	return handleTrinoQuery(ctx, client, []string{query}, flags)
 }
 
 // handleTrinoQueryWithPagination executes a Trino query with pagination support
-func handleTrinoQueryWithPagination(ctx context.Context, client *td.Client, args []string, flags Flags, pageSize int) {
+func handleTrinoQueryWithPagination(ctx context.Context, client *td.Client, args []string, flags Flags, pageSize int) error {
 	if client == nil {
-		log.Fatal("Client is not initialized")
+		return errors.New("client is not initialized")
 	}
 	if len(args) == 0 {
-		log.Fatal("Query is required")
+		return errors.New("query is required")
 	}
 
 	query := args[0]
@@ -1248,7 +1148,6 @@ func handleTrinoQueryWithPagination(ctx context.Context, client *td.Client, args
 		fmt.Printf("Executing query with pagination (page size: %d): %s\n", pageSize, query)
 	}
 
-	// Create Trino client using the SDK client's HTTP transport and OTEL config
 	trinoConfig := td.TDTrinoClientConfig{
 		APIKey:        flags.APIKey,
 		Region:        flags.Region,
@@ -1262,47 +1161,46 @@ func handleTrinoQueryWithPagination(ctx context.Context, client *td.Client, args
 
 	trinoClient, err := td.NewTDTrinoClient(trinoConfig)
 	if err != nil {
-		trinoClientError("create Trino client for pagination", err, flags)
+		return trinoClientError("create Trino client for pagination", err, flags)
 	}
 	defer trinoClient.Close()
 
-	// Execute query
 	start := time.Now()
 	rows, err := trinoClient.Query(ctx, query)
 	if err != nil {
-		enhanceTrinoQueryError("execute query", err, query, flags)
+		return enhanceTrinoQueryError("execute query", err, query, flags)
 	}
 	defer rows.Close()
 
-	// Get column info
 	columns, err := rows.Columns()
 	if err != nil {
-		log.Fatalf("Failed to get columns: %v", err)
+		return wrapErr(err, "failed to get columns", flags.Verbose)
 	}
 
-	// Prepare output
 	var output io.Writer = os.Stdout
 	if flags.Output != "" {
 		file, err := os.Create(flags.Output)
 		if err != nil {
-			log.Fatalf("Failed to create output file: %v", err)
+			return wrapErr(err, "failed to create output file", flags.Verbose)
 		}
 		defer file.Close()
 		output = file
 	}
 
-	// Format and display results with pagination
-	totalRows := handleTrinoQueryTableWithPagination(rows, columns, output, pageSize)
+	totalRows, err := handleTrinoQueryTableWithPagination(rows, columns, output, pageSize)
+	if err != nil {
+		return err
+	}
 
 	if flags.Verbose {
 		fmt.Printf("Query completed in %v, %d rows total\n", time.Since(start), totalRows)
 	}
+	return nil
 }
 
 // handleTrinoVersion shows Trino version information
-func handleTrinoVersion(ctx context.Context, client *td.Client, _ []string, flags Flags) {
+func handleTrinoVersion(ctx context.Context, client *td.Client, _ []string, flags Flags) error {
 	query := "SELECT version()"
 
-	// Execute as a regular query
-	handleTrinoQuery(ctx, client, []string{query}, flags)
+	return handleTrinoQuery(ctx, client, []string{query}, flags)
 }

--- a/cmd/tdcli/users.go
+++ b/cmd/tdcli/users.go
@@ -2,64 +2,18 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"text/tabwriter"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-func handleUserCommands(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	if len(args) == 0 || args[0] == "help" {
-		printUserUsage()
-		return
-	}
-
-	subcommand := args[0]
-	subArgs := args[1:]
-
-	switch subcommand {
-	case "list", "ls":
-		handleUserList(ctx, client, flags)
-	case "get", "show":
-		handleUserGet(ctx, client, subArgs, flags)
-	default:
-		fmt.Printf("Unknown user subcommand: %s\n", subcommand)
-		printUserUsage()
-		os.Exit(1)
-	}
-}
-
-func printUserUsage() {
-	fmt.Printf(`User Management Commands
-
-USAGE:
-    tdcli users <subcommand> [options]
-    tdcli user <subcommand> [options]
-
-SUBCOMMANDS:
-    list, ls               List users
-    get, show <email>      Get user details by email
-
-OPTIONS:
-    --format FORMAT        Output format (json, table, csv)
-    --output FILE          Write output to file
-    --verbose, -v          Verbose output
-
-EXAMPLES:
-    tdcli user list
-    tdcli user show user@example.com
-    tdcli user list --format csv --output users.csv
-
-`)
-}
-
-func handleUserList(ctx context.Context, client *td.Client, flags Flags) {
+func handleUserList(ctx context.Context, client *td.Client, flags Flags) error {
 	users, err := client.Users.List(ctx)
 	if err != nil {
-		handleError(err, "Failed to list users", flags.Verbose)
-		return
+		return wrapErr(err, "failed to list users", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -104,22 +58,20 @@ func handleUserList(ctx context.Context, client *td.Client, flags Flags) {
 	}
 
 	if err := formatAndWriteOutput(users, flags.Format, flags.Output, "id,name,email,account_id,created_at,administrator,email_verified,restricted", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapErr(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }
 
-func handleUserGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+func handleUserGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) == 0 {
-		fmt.Println("Error: User email required")
-		fmt.Println("Usage: tdcli user get <email>")
-		os.Exit(1)
+		return errors.New("user email required\nUsage: tdcli user get <email>")
 	}
 
 	email := args[0]
 	user, err := client.Users.Get(ctx, email)
 	if err != nil {
-		handleError(err, "Failed to get user", flags.Verbose)
-		return
+		return wrapErr(err, "failed to get user", flags.Verbose)
 	}
 
 	csvFormatter := func(data interface{}) string {
@@ -155,6 +107,7 @@ func handleUserGet(ctx context.Context, client *td.Client, args []string, flags 
 	}
 
 	if err := formatAndWriteOutput(user, flags.Format, flags.Output, "id,name,email,account_id,created_at,administrator,email_verified,restricted", csvFormatter, tableFormatter); err != nil {
-		handleError(err, "Failed to write output", flags.Verbose)
+		return wrapErr(err, "failed to write output", flags.Verbose)
 	}
+	return nil
 }

--- a/cmd/tdcli/workflow/types.go
+++ b/cmd/tdcli/workflow/types.go
@@ -3,8 +3,8 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
@@ -42,40 +42,36 @@ type WorkflowInitCmd struct {
 }
 
 func (w *WorkflowInitCmd) Run(ctx *CLIContext) error {
-	HandleWorkflowInit(ctx.Context, []string{w.ProjectName}, ctx.GlobalFlags)
-	return nil
+	return HandleWorkflowInit(ctx.Context, []string{w.ProjectName}, ctx.GlobalFlags)
 }
 
-// Helper functions for consistent output
-func PrintJSON(v interface{}) {
+// PrintJSON encodes the value as indented JSON to stdout.
+func PrintJSON(v interface{}) error {
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 	encoder.SetEscapeHTML(false)
 	if err := encoder.Encode(v); err != nil {
-		log.Fatalf("Failed to marshal JSON: %v", err)
+		return fmt.Errorf("failed to marshal JSON: %w", err)
 	}
+	return nil
 }
 
-// CaptureErrors signals HandleError to panic instead of calling log.Fatalf.
-// Set by the main package's runHandlerWithErrorCapture when wrapping commands.
-var CaptureErrors = false
-
-func HandleError(err error, message string, verbose bool) {
-	if err != nil {
-		if CaptureErrors {
-			if verbose {
-				panic(fmt.Errorf("%s: %v", message, err))
-			}
-			panic(err)
-		}
+// wrapError formats an error with context for propagation up the call stack.
+// When verbose, it appends TD API status details when available.
+func wrapError(err error, message string, verbose bool) error {
+	if err == nil {
+		return nil
 	}
 	if verbose {
-		if tdErr, ok := err.(*td.ErrorResponse); ok {
-			log.Printf("API Error: %s\n", tdErr.Error())
-			if tdErr.Response != nil {
-				log.Printf("Status: %s\n", tdErr.Response.Status)
-			}
+		var tdErr *td.ErrorResponse
+		if errors.As(err, &tdErr) && tdErr.Response != nil {
+			return fmt.Errorf("%s: %w (status: %s)", message, err, tdErr.Response.Status)
 		}
 	}
-	log.Fatalf("%s: %v", message, err)
+	return fmt.Errorf("%s: %w", message, err)
+}
+
+// usageError builds an error for a missing/invalid argument.
+func usageError(message string) error {
+	return errors.New(message)
 }

--- a/cmd/tdcli/workflow/workflow_attempts.go
+++ b/cmd/tdcli/workflow/workflow_attempts.go
@@ -4,34 +4,31 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"text/tabwriter"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-// Workflow attempt handlers
-func HandleWorkflowAttemptList(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowAttemptList lists workflow attempts
+func HandleWorkflowAttemptList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Workflow ID required")
+		return usageError("Workflow ID required")
 	}
-
-	workflowID := args[0]
 
 	opts := &td.WorkflowAttemptListOptions{
 		Limit:  100,
 		Offset: 0,
 	}
 
-	resp, err := client.Workflow.ListWorkflowAttempts(ctx, workflowID, opts)
+	resp, err := client.Workflow.ListWorkflowAttempts(ctx, args[0], opts)
 	if err != nil {
-		HandleError(err, "Failed to list workflow attempts", flags.Verbose)
+		return wrapError(err, "failed to list workflow attempts", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		PrintJSON(resp)
+		return PrintJSON(resp)
 	case "csv":
 		fmt.Println("id,index,status,created_at,finished_at")
 		for _, attempt := range resp.Attempts {
@@ -47,7 +44,7 @@ func HandleWorkflowAttemptList(ctx context.Context, client *td.Client, args []st
 	default:
 		if len(resp.Attempts) == 0 {
 			fmt.Println("No attempts found")
-			return
+			return nil
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -65,25 +62,23 @@ func HandleWorkflowAttemptList(ctx context.Context, client *td.Client, args []st
 		w.Flush()
 		fmt.Printf("\nTotal: %d attempts\n", len(resp.Attempts))
 	}
+	return nil
 }
 
-func HandleWorkflowAttemptGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowAttemptGet retrieves a workflow attempt
+func HandleWorkflowAttemptGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		log.Fatal("Workflow ID and attempt ID required")
+		return usageError("Workflow ID and attempt ID required")
 	}
 
-	workflowID := args[0]
-
-	attemptID := args[1]
-
-	attempt, err := client.Workflow.GetWorkflowAttempt(ctx, workflowID, attemptID)
+	attempt, err := client.Workflow.GetWorkflowAttempt(ctx, args[0], args[1])
 	if err != nil {
-		HandleError(err, "Failed to get workflow attempt", flags.Verbose)
+		return wrapError(err, "failed to get workflow attempt", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		PrintJSON(attempt)
+		return PrintJSON(attempt)
 	case "csv":
 		fmt.Println("id,index,status,created_at,finished_at,done,success")
 		finishedAt := ""
@@ -120,48 +115,43 @@ func HandleWorkflowAttemptGet(ctx context.Context, client *td.Client, args []str
 			fmt.Printf("  %s\n", paramsJSON)
 		}
 	}
+	return nil
 }
 
-func HandleWorkflowAttemptKill(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowAttemptKill kills a workflow attempt
+func HandleWorkflowAttemptKill(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		log.Fatal("Workflow ID and attempt ID required")
+		return usageError("Workflow ID and attempt ID required")
 	}
 
-	workflowID := args[0]
-
-	attemptID := args[1]
-
-	err := client.Workflow.KillWorkflowAttempt(ctx, workflowID, attemptID)
-	if err != nil {
-		HandleError(err, "Failed to kill workflow attempt", flags.Verbose)
+	if err := client.Workflow.KillWorkflowAttempt(ctx, args[0], args[1]); err != nil {
+		return wrapError(err, "failed to kill workflow attempt", flags.Verbose)
 	}
 
-	fmt.Printf("Workflow attempt %s killed successfully\n", attemptID)
+	fmt.Printf("Workflow attempt %s killed successfully\n", args[1])
+	return nil
 }
 
-func HandleWorkflowAttemptRetry(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowAttemptRetry retries a workflow attempt
+func HandleWorkflowAttemptRetry(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		log.Fatal("Workflow ID and attempt ID required")
+		return usageError("Workflow ID and attempt ID required")
 	}
-
-	workflowID := args[0]
-
-	attemptID := args[1]
 
 	var params map[string]interface{}
 	if len(args) > 2 {
-		err := json.Unmarshal([]byte(args[2]), &params)
-		if err != nil {
-			log.Fatalf("Invalid parameters JSON: %v", err)
+		if err := json.Unmarshal([]byte(args[2]), &params); err != nil {
+			return usageError(fmt.Sprintf("Invalid parameters JSON: %v", err))
 		}
 	}
 
-	attempt, err := client.Workflow.RetryWorkflowAttempt(ctx, workflowID, attemptID, params)
+	attempt, err := client.Workflow.RetryWorkflowAttempt(ctx, args[0], args[1], params)
 	if err != nil {
-		HandleError(err, "Failed to retry workflow attempt", flags.Verbose)
+		return wrapError(err, "failed to retry workflow attempt", flags.Verbose)
 	}
 
 	fmt.Printf("Workflow attempt retried successfully\n")
 	fmt.Printf("New Attempt ID: %s\n", attempt.ID)
 	fmt.Printf("Status: %s\n", attempt.Status)
+	return nil
 }

--- a/cmd/tdcli/workflow/workflow_core.go
+++ b/cmd/tdcli/workflow/workflow_core.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,8 +12,8 @@ import (
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-// Workflow handlers
-func HandleWorkflowList(ctx context.Context, client *td.Client, flags Flags) {
+// HandleWorkflowList lists workflows
+func HandleWorkflowList(ctx context.Context, client *td.Client, flags Flags) error {
 	opts := &td.WorkflowListOptions{
 		Limit:  100,
 		Offset: 0,
@@ -22,12 +21,12 @@ func HandleWorkflowList(ctx context.Context, client *td.Client, flags Flags) {
 
 	resp, err := client.Workflow.ListWorkflows(ctx, opts)
 	if err != nil {
-		HandleError(err, "Failed to list workflows", flags.Verbose)
+		return wrapError(err, "failed to list workflows", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		PrintJSON(resp)
+		return PrintJSON(resp)
 	case "csv":
 		fmt.Println("id,name,project,status,created_at,updated_at")
 		for _, workflow := range resp.Workflows {
@@ -46,7 +45,7 @@ func HandleWorkflowList(ctx context.Context, client *td.Client, flags Flags) {
 	default:
 		if len(resp.Workflows) == 0 {
 			fmt.Println("No workflows found")
-			return
+			return nil
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -59,23 +58,25 @@ func HandleWorkflowList(ctx context.Context, client *td.Client, flags Flags) {
 		w.Flush()
 		fmt.Printf("\nTotal: %d workflows\n", len(resp.Workflows))
 	}
+	return nil
 }
 
-func HandleWorkflowGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowGet retrieves a workflow
+func HandleWorkflowGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Workflow ID required")
+		return usageError("Workflow ID required")
 	}
 
 	workflowID := args[0]
 
 	workflow, err := client.Workflow.GetWorkflow(ctx, workflowID)
 	if err != nil {
-		HandleError(err, "Failed to get workflow", flags.Verbose)
+		return wrapError(err, "failed to get workflow", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		PrintJSON(workflow)
+		return PrintJSON(workflow)
 	case "csv":
 		fmt.Println("id,name,project,status,revision,timezone,created_at,updated_at")
 		createdAt := ""
@@ -113,29 +114,28 @@ func HandleWorkflowGet(ctx context.Context, client *td.Client, args []string, fl
 			fmt.Printf("\nConfig:\n%+v\n", workflow.Config)
 		}
 	}
+	return nil
 }
 
-func HandleWorkflowInit(ctx context.Context, args []string, flags Flags) {
+// HandleWorkflowInit scaffolds a workflow project on disk.
+func HandleWorkflowInit(ctx context.Context, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Project name required")
+		return usageError("Project name required")
 	}
 	projectName := args[0]
 
-	// Create project directory
 	if err := os.Mkdir(projectName, 0755); err != nil {
 		if os.IsExist(err) {
-			log.Fatalf("Directory '%s' already exists", projectName)
+			return fmt.Errorf("directory %q already exists", projectName)
 		}
-		HandleError(err, "Failed to create project directory", flags.Verbose)
+		return wrapError(err, "failed to create project directory", flags.Verbose)
 	}
 
-	// Create queries subdirectory
 	queriesDir := filepath.Join(projectName, "queries")
 	if err := os.Mkdir(queriesDir, 0755); err != nil {
-		HandleError(err, "Failed to create queries directory", flags.Verbose)
+		return wrapError(err, "failed to create queries directory", flags.Verbose)
 	}
 
-	// Create workflow.dig file
 	workflowDigContent := `timezone: UTC
 
 +setup:
@@ -148,99 +148,102 @@ func HandleWorkflowInit(ctx context.Context, args []string, flags Flags) {
 `
 	workflowDigPath := filepath.Join(projectName, "workflow.dig")
 	if err := os.WriteFile(workflowDigPath, []byte(workflowDigContent), 0644); err != nil {
-		HandleError(err, "Failed to create workflow.dig file", flags.Verbose)
+		return wrapError(err, "failed to create workflow.dig file", flags.Verbose)
 	}
 
-	// Create sample_query.sql file
 	sampleQueryContent := `-- Sample query: select the count of records from a sample table
 SELECT count(1) FROM www_access;
 `
 	sampleQueryPath := filepath.Join(queriesDir, "sample_query.sql")
 	if err := os.WriteFile(sampleQueryPath, []byte(sampleQueryContent), 0644); err != nil {
-		HandleError(err, "Failed to create sample_query.sql file", flags.Verbose)
+		return wrapError(err, "failed to create sample_query.sql file", flags.Verbose)
 	}
 
 	fmt.Printf("✅ Sample workflow project '%s' created successfully.\n", projectName)
 	fmt.Println("To push this project to Treasure Data, run:")
 	fmt.Printf("  tdcli workflow projects push %s %s\n", projectName, projectName)
+	return nil
 }
 
-func HandleWorkflowCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowCreate creates a workflow
+func HandleWorkflowCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		log.Fatal("Name, project, and config required")
+		return usageError("Name, project, and config required")
 	}
 
 	workflow, err := client.Workflow.CreateWorkflow(ctx, args[0], args[1], args[2])
 	if err != nil {
-		HandleError(err, "Failed to create workflow", flags.Verbose)
+		return wrapError(err, "failed to create workflow", flags.Verbose)
 	}
 
 	fmt.Printf("Workflow created successfully\n")
 	fmt.Printf("ID: %s\n", workflow.ID)
 	fmt.Printf("Name: %s\n", workflow.Name)
+	return nil
 }
 
-func HandleWorkflowUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowUpdate updates a workflow
+func HandleWorkflowUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		log.Fatal("Workflow ID and updates (key=value) required")
+		return usageError("Workflow ID and updates (key=value) required")
 	}
 
 	workflowID := args[0]
 
 	updates := make(map[string]string)
-	// Parse key=value pairs
 	for _, arg := range args[1:] {
 		parts := strings.SplitN(arg, "=", 2)
 		if len(parts) != 2 {
-			log.Fatalf("Invalid update format: %s (expected key=value)", arg)
+			return usageError(fmt.Sprintf("Invalid update format: %s (expected key=value)", arg))
 		}
 		updates[parts[0]] = parts[1]
 	}
 
 	workflow, err := client.Workflow.UpdateWorkflow(ctx, workflowID, updates)
 	if err != nil {
-		HandleError(err, "Failed to update workflow", flags.Verbose)
+		return wrapError(err, "failed to update workflow", flags.Verbose)
 	}
 
 	fmt.Printf("Workflow %s updated successfully\n", workflow.ID)
+	return nil
 }
 
-func HandleWorkflowDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowDelete deletes a workflow
+func HandleWorkflowDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Workflow ID required")
+		return usageError("Workflow ID required")
 	}
 
-	workflowID := args[0]
-
-	err := client.Workflow.DeleteWorkflow(ctx, workflowID)
-	if err != nil {
-		HandleError(err, "Failed to delete workflow", flags.Verbose)
+	if err := client.Workflow.DeleteWorkflow(ctx, args[0]); err != nil {
+		return wrapError(err, "failed to delete workflow", flags.Verbose)
 	}
 
-	fmt.Printf("Workflow %s deleted successfully\n", workflowID)
+	fmt.Printf("Workflow %s deleted successfully\n", args[0])
+	return nil
 }
 
-func HandleWorkflowStart(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowStart starts a workflow
+func HandleWorkflowStart(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Workflow ID required")
+		return usageError("Workflow ID required")
 	}
 
 	workflowID := args[0]
 
 	var params map[string]interface{}
 	if len(args) > 1 {
-		err := json.Unmarshal([]byte(args[1]), &params)
-		if err != nil {
-			log.Fatalf("Invalid parameters JSON: %v", err)
+		if err := json.Unmarshal([]byte(args[1]), &params); err != nil {
+			return usageError(fmt.Sprintf("Invalid parameters JSON: %v", err))
 		}
 	}
 
 	attempt, err := client.Workflow.StartWorkflow(ctx, workflowID, params)
 	if err != nil {
-		HandleError(err, "Failed to start workflow", flags.Verbose)
+		return wrapError(err, "failed to start workflow", flags.Verbose)
 	}
 
 	fmt.Printf("Workflow started successfully\n")
 	fmt.Printf("Attempt ID: %s\n", attempt.ID)
 	fmt.Printf("Status: %s\n", attempt.Status)
+	return nil
 }

--- a/cmd/tdcli/workflow/workflow_hooks.go
+++ b/cmd/tdcli/workflow/workflow_hooks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -13,26 +12,24 @@ import (
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-// Workflow hooks handlers
-func HandleWorkflowHooksShow(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowHooksShow displays the configured hooks for a project.
+func HandleWorkflowHooksShow(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Project directory path required")
+		return usageError("Project directory path required")
 	}
 
 	dirPath := args[0]
 	configPath := filepath.Join(dirPath, ".td-hooks.json")
 
-	// Check if config file exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		fmt.Printf("No hooks configuration found at %s\n", configPath)
 		fmt.Println("Run 'tdcli workflow projects hooks init' to create a hooks configuration file.")
-		return
+		return nil
 	}
 
-	// Read and display config
 	configData, err := os.ReadFile(configPath)
 	if err != nil {
-		HandleError(err, "Failed to read hooks configuration", flags.Verbose)
+		return wrapError(err, "failed to read hooks configuration", flags.Verbose)
 	}
 
 	switch flags.Format {
@@ -41,12 +38,12 @@ func HandleWorkflowHooksShow(ctx context.Context, client *td.Client, args []stri
 	default:
 		var config td.WorkflowHooksConfig
 		if err := json.Unmarshal(configData, &config); err != nil {
-			HandleError(err, "Failed to parse hooks configuration", flags.Verbose)
+			return wrapError(err, "failed to parse hooks configuration", flags.Verbose)
 		}
 
 		if len(config.PreUploadHooks) == 0 {
 			fmt.Println("No pre-upload hooks configured")
-			return
+			return nil
 		}
 
 		fmt.Printf("Pre-upload hooks (%d):\n", len(config.PreUploadHooks))
@@ -62,23 +59,23 @@ func HandleWorkflowHooksShow(ctx context.Context, client *td.Client, args []stri
 			}
 		}
 	}
+	return nil
 }
 
-func HandleWorkflowHooksInit(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowHooksInit creates a default hooks configuration file.
+func HandleWorkflowHooksInit(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Project directory path required")
+		return usageError("Project directory path required")
 	}
 
 	dirPath := args[0]
 	configPath := filepath.Join(dirPath, ".td-hooks.json")
 
-	// Check if config file already exists
 	if _, err := os.Stat(configPath); err == nil {
 		fmt.Printf("Hooks configuration file already exists at %s\n", configPath)
-		return
+		return nil
 	}
 
-	// Create default configuration with safe example
 	config := td.WorkflowHooksConfig{
 		PreUploadHooks: []td.WorkflowHook{
 			{
@@ -91,57 +88,54 @@ func HandleWorkflowHooksInit(ctx context.Context, client *td.Client, args []stri
 		},
 	}
 
-	// Marshal to JSON with indentation
 	configData, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		HandleError(err, "Failed to create hooks configuration", flags.Verbose)
+		return wrapError(err, "failed to create hooks configuration", flags.Verbose)
 	}
 
-	// Write to file
 	if err := os.WriteFile(configPath, configData, 0644); err != nil {
-		HandleError(err, "Failed to write hooks configuration file", flags.Verbose)
+		return wrapError(err, "failed to write hooks configuration file", flags.Verbose)
 	}
 
 	fmt.Printf("Created hooks configuration file at %s\n", configPath)
 	fmt.Println("Edit this file to configure your pre-upload hooks.")
+	return nil
 }
 
-func HandleWorkflowHooksAdd(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowHooksAdd appends a new hook to the configuration.
+func HandleWorkflowHooksAdd(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 6 {
-		log.Fatal("Path, name, timeout, fail_on_error, working_dir, and command required")
+		return usageError("Path, name, timeout, fail_on_error, working_dir, and command required")
 	}
 
 	dirPath := args[0]
 	name := args[1]
 	timeout, err := strconv.Atoi(args[2])
 	if err != nil {
-		log.Fatalf("Invalid timeout: %s", args[2])
+		return usageError(fmt.Sprintf("Invalid timeout: %s", args[2]))
 	}
 	failOnError, err := strconv.ParseBool(args[3])
 	if err != nil {
-		log.Fatalf("Invalid fail_on_error: %s", args[3])
+		return usageError(fmt.Sprintf("Invalid fail_on_error: %s", args[3]))
 	}
 	workingDir := args[4]
 	command := args[5:]
 
 	configPath := filepath.Join(dirPath, ".td-hooks.json")
 
-	// Load existing config or create new one
 	var config td.WorkflowHooksConfig
 	if configData, err := os.ReadFile(configPath); err == nil {
 		if err := json.Unmarshal(configData, &config); err != nil {
-			HandleError(err, "Failed to parse existing hooks configuration", flags.Verbose)
+			return wrapError(err, "failed to parse existing hooks configuration", flags.Verbose)
 		}
 	}
 
-	// Check if hook with same name already exists
 	for _, hook := range config.PreUploadHooks {
 		if hook.Name == name {
-			log.Fatalf("Hook with name '%s' already exists", name)
+			return fmt.Errorf("hook with name %q already exists", name)
 		}
 	}
 
-	// Add new hook
 	newHook := td.WorkflowHook{
 		Name:        name,
 		Command:     command,
@@ -152,40 +146,39 @@ func HandleWorkflowHooksAdd(ctx context.Context, client *td.Client, args []strin
 
 	config.PreUploadHooks = append(config.PreUploadHooks, newHook)
 
-	// Write updated config
 	configData, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		HandleError(err, "Failed to serialize hooks configuration", flags.Verbose)
+		return wrapError(err, "failed to serialize hooks configuration", flags.Verbose)
 	}
 
 	if err := os.WriteFile(configPath, configData, 0644); err != nil {
-		HandleError(err, "Failed to write hooks configuration file", flags.Verbose)
+		return wrapError(err, "failed to write hooks configuration file", flags.Verbose)
 	}
 
 	fmt.Printf("Added hook '%s' to %s\n", name, configPath)
+	return nil
 }
 
-func HandleWorkflowHooksRemove(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowHooksRemove removes a hook from the configuration.
+func HandleWorkflowHooksRemove(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		log.Fatal("Project directory path and hook name required")
+		return usageError("Project directory path and hook name required")
 	}
 
 	dirPath := args[0]
 	hookName := args[1]
 	configPath := filepath.Join(dirPath, ".td-hooks.json")
 
-	// Load existing config
 	configData, err := os.ReadFile(configPath)
 	if err != nil {
-		HandleError(err, "Failed to read hooks configuration", flags.Verbose)
+		return wrapError(err, "failed to read hooks configuration", flags.Verbose)
 	}
 
 	var config td.WorkflowHooksConfig
 	if err := json.Unmarshal(configData, &config); err != nil {
-		HandleError(err, "Failed to parse hooks configuration", flags.Verbose)
+		return wrapError(err, "failed to parse hooks configuration", flags.Verbose)
 	}
 
-	// Find and remove hook
 	found := false
 	var updatedHooks []td.WorkflowHook
 	for _, hook := range config.PreUploadHooks {
@@ -197,61 +190,58 @@ func HandleWorkflowHooksRemove(ctx context.Context, client *td.Client, args []st
 	}
 
 	if !found {
-		log.Fatalf("Hook '%s' not found", hookName)
+		return fmt.Errorf("hook %q not found", hookName)
 	}
 
 	config.PreUploadHooks = updatedHooks
 
-	// Write updated config
 	updatedConfigData, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		HandleError(err, "Failed to serialize hooks configuration", flags.Verbose)
+		return wrapError(err, "failed to serialize hooks configuration", flags.Verbose)
 	}
 
 	if err := os.WriteFile(configPath, updatedConfigData, 0644); err != nil {
-		HandleError(err, "Failed to write hooks configuration file", flags.Verbose)
+		return wrapError(err, "failed to write hooks configuration file", flags.Verbose)
 	}
 
 	fmt.Printf("Removed hook '%s' from %s\n", hookName, configPath)
+	return nil
 }
 
-func HandleWorkflowHooksValidate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowHooksValidate validates the hooks configuration.
+func HandleWorkflowHooksValidate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Project directory path required")
+		return usageError("Project directory path required")
 	}
 
 	dirPath := args[0]
 
 	fmt.Printf("Validating pre-upload hooks configuration in %s...\n", dirPath)
 
-	// Load hooks configuration
 	configPath := filepath.Join(dirPath, ".td-hooks.json")
 
-	// Check if config file exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		fmt.Println("No hooks configuration found")
-		return
+		return nil
 	}
 
-	// Read and parse config file
 	configData, err := os.ReadFile(configPath)
 	if err != nil {
-		HandleError(err, "Failed to read hooks configuration", flags.Verbose)
+		return wrapError(err, "failed to read hooks configuration", flags.Verbose)
 	}
 
 	var config td.WorkflowHooksConfig
 	if err := json.Unmarshal(configData, &config); err != nil {
-		HandleError(err, "Failed to parse hooks configuration", flags.Verbose)
+		return wrapError(err, "failed to parse hooks configuration", flags.Verbose)
 	}
 
 	if len(config.PreUploadHooks) == 0 {
 		fmt.Println("No pre-upload hooks configured")
-		return
+		return nil
 	}
 
 	fmt.Printf("Found %d pre-upload hook(s)\n", len(config.PreUploadHooks))
 
-	// Display hooks with validation status
 	for i, hook := range config.PreUploadHooks {
 		fmt.Printf("%d. Hook '%s': %s\n", i+1, hook.Name, strings.Join(hook.Command, " "))
 		if hook.WorkingDir != "" {
@@ -265,4 +255,5 @@ func HandleWorkflowHooksValidate(ctx context.Context, client *td.Client, args []
 
 	fmt.Println("\n✅ All hooks have been validated and appear to be correctly configured.")
 	fmt.Println("Use 'tdcli workflow projects push' to execute hooks during actual upload")
+	return nil
 }

--- a/cmd/tdcli/workflow/workflow_logs.go
+++ b/cmd/tdcli/workflow/workflow_logs.go
@@ -3,42 +3,36 @@ package workflow
 import (
 	"context"
 	"fmt"
-	"log"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-// Workflow log handlers
-func HandleWorkflowAttemptLog(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowAttemptLog gets the log for a workflow attempt.
+func HandleWorkflowAttemptLog(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		log.Fatal("Workflow ID and attempt ID required")
+		return usageError("Workflow ID and attempt ID required")
 	}
 
-	workflowID := args[0]
-
-	attemptID := args[1]
-
-	logContent, err := client.Workflow.GetWorkflowAttemptLog(ctx, workflowID, attemptID)
+	logContent, err := client.Workflow.GetWorkflowAttemptLog(ctx, args[0], args[1])
 	if err != nil {
-		HandleError(err, "Failed to get workflow attempt log", flags.Verbose)
+		return wrapError(err, "failed to get workflow attempt log", flags.Verbose)
 	}
 
 	fmt.Print(logContent)
+	return nil
 }
 
-func HandleWorkflowTaskLog(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowTaskLog gets the log for a task within a workflow attempt.
+func HandleWorkflowTaskLog(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		log.Fatal("Workflow ID, attempt ID, and task ID required")
+		return usageError("Workflow ID, attempt ID, and task ID required")
 	}
 
-	workflowID := args[0]
-
-	attemptID := args[1]
-
-	logContent, err := client.Workflow.GetWorkflowTaskLog(ctx, workflowID, attemptID, args[2])
+	logContent, err := client.Workflow.GetWorkflowTaskLog(ctx, args[0], args[1], args[2])
 	if err != nil {
-		HandleError(err, "Failed to get workflow task log", flags.Verbose)
+		return wrapError(err, "failed to get workflow task log", flags.Verbose)
 	}
 
 	fmt.Print(logContent)
+	return nil
 }

--- a/cmd/tdcli/workflow/workflow_projects.go
+++ b/cmd/tdcli/workflow/workflow_projects.go
@@ -3,7 +3,6 @@ package workflow
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -12,16 +11,16 @@ import (
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-// Workflow project handlers
-func HandleWorkflowProjectList(ctx context.Context, client *td.Client, flags Flags) {
+// HandleWorkflowProjectList lists workflow projects.
+func HandleWorkflowProjectList(ctx context.Context, client *td.Client, flags Flags) error {
 	resp, err := client.Workflow.ListProjects(ctx)
 	if err != nil {
-		HandleError(err, "Failed to list workflow projects", flags.Verbose)
+		return wrapError(err, "failed to list workflow projects", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		PrintJSON(resp)
+		return PrintJSON(resp)
 	case "csv":
 		fmt.Println("id,name,revision,archive_type,created_at,updated_at")
 		for _, project := range resp.Projects {
@@ -33,7 +32,7 @@ func HandleWorkflowProjectList(ctx context.Context, client *td.Client, flags Fla
 	default:
 		if len(resp.Projects) == 0 {
 			fmt.Println("No projects found")
-			return
+			return nil
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -46,33 +45,32 @@ func HandleWorkflowProjectList(ctx context.Context, client *td.Client, flags Fla
 		w.Flush()
 		fmt.Printf("\nTotal: %d projects\n", len(resp.Projects))
 	}
+	return nil
 }
 
-func HandleWorkflowProjectGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowProjectGet retrieves a workflow project by ID or name.
+func HandleWorkflowProjectGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Project ID or name required")
+		return usageError("Project ID or name required")
 	}
 
 	projectIdentifier := args[0]
 	var project *td.WorkflowProject
 	var err error
 
-	// Try to parse as project ID first (numeric)
 	if _, parseErr := strconv.Atoi(projectIdentifier); parseErr == nil {
-		// It's a numeric ID
 		project, err = client.Workflow.GetProject(ctx, projectIdentifier)
 	} else {
-		// It's not numeric, try to get by name
 		project, err = client.Workflow.GetProjectByName(ctx, projectIdentifier)
 	}
 
 	if err != nil {
-		HandleError(err, "Failed to get workflow project", flags.Verbose)
+		return wrapError(err, "failed to get workflow project", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		PrintJSON(project)
+		return PrintJSON(project)
 	case "csv":
 		fmt.Println("id,name,revision,archive_type,archive_md5,created_at,updated_at,deleted_at")
 		deletedAt := ""
@@ -97,62 +95,61 @@ func HandleWorkflowProjectGet(ctx context.Context, client *td.Client, args []str
 			fmt.Printf("Deleted: %s\n", project.DeletedAt.Time.UTC().Format("2006-01-02 15:04:05"))
 		}
 	}
+	return nil
 }
 
-func HandleWorkflowProjectCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowProjectCreate creates a workflow project from a directory or archive.
+func HandleWorkflowProjectCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		log.Fatal("Project name and path (directory or archive file) required")
+		return usageError("Project name and path (directory or archive file) required")
 	}
 
 	path := args[1]
 
-	// Check if the path is a directory or file
 	fileInfo, err := os.Stat(path)
 	if err != nil {
-		log.Fatalf("Failed to access path %s: %v", path, err)
+		return wrapError(err, fmt.Sprintf("failed to access path %s", path), flags.Verbose)
 	}
 
 	var project *td.WorkflowProject
 
 	if fileInfo.IsDir() {
-		// Create project from directory
 		fmt.Printf("Creating project from directory: %s\n", path)
 		project, err = client.Workflow.CreateProjectFromDirectory(ctx, args[0], path)
 	} else {
-		// Create project from archive file
 		fmt.Printf("Creating project from archive file: %s\n", path)
 		archiveData, readErr := os.ReadFile(path)
 		if readErr != nil {
-			log.Fatalf("Failed to read archive file: %v", readErr)
+			return wrapError(readErr, "failed to read archive file", flags.Verbose)
 		}
 		project, err = client.Workflow.CreateProject(ctx, args[0], archiveData)
 	}
 
 	if err != nil {
-		HandleError(err, "Failed to create workflow project", flags.Verbose)
+		return wrapError(err, "failed to create workflow project", flags.Verbose)
 	}
 
 	fmt.Printf("Project created successfully\n")
 	fmt.Printf("ID: %s\n", project.ID)
 	fmt.Printf("Name: %s\n", project.Name)
 	fmt.Printf("Revision: %s\n", project.Revision)
+	return nil
 }
 
-func HandleWorkflowProjectWorkflows(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowProjectWorkflows lists workflows belonging to a project.
+func HandleWorkflowProjectWorkflows(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Project ID required")
+		return usageError("Project ID required")
 	}
 
-	projectID := args[0]
-
-	resp, err := client.Workflow.ListProjectWorkflows(ctx, projectID)
+	resp, err := client.Workflow.ListProjectWorkflows(ctx, args[0])
 	if err != nil {
-		HandleError(err, "Failed to list project workflows", flags.Verbose)
+		return wrapError(err, "failed to list project workflows", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		PrintJSON(resp)
+		return PrintJSON(resp)
 	case "csv":
 		fmt.Println("id,name,project,status,created_at,updated_at")
 		for _, workflow := range resp.Workflows {
@@ -171,7 +168,7 @@ func HandleWorkflowProjectWorkflows(ctx context.Context, client *td.Client, args
 	default:
 		if len(resp.Workflows) == 0 {
 			fmt.Println("No workflows found in this project")
-			return
+			return nil
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -184,23 +181,23 @@ func HandleWorkflowProjectWorkflows(ctx context.Context, client *td.Client, args
 		w.Flush()
 		fmt.Printf("\nTotal: %d workflows\n", len(resp.Workflows))
 	}
+	return nil
 }
 
-func HandleWorkflowProjectSecretsList(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowProjectSecretsList lists project secrets.
+func HandleWorkflowProjectSecretsList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Project ID required")
+		return usageError("Project ID required")
 	}
 
-	projectID := args[0]
-
-	resp, err := client.Workflow.GetProjectSecrets(ctx, projectID)
+	resp, err := client.Workflow.GetProjectSecrets(ctx, args[0])
 	if err != nil {
-		HandleError(err, "Failed to list project secrets", flags.Verbose)
+		return wrapError(err, "failed to list project secrets", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		PrintJSON(resp)
+		return PrintJSON(resp)
 	case "csv":
 		fmt.Println("key,value")
 		for key, value := range resp.Secrets {
@@ -209,7 +206,7 @@ func HandleWorkflowProjectSecretsList(ctx context.Context, client *td.Client, ar
 	default:
 		if len(resp.Secrets) == 0 {
 			fmt.Println("No secrets found in this project")
-			return
+			return nil
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -220,84 +217,82 @@ func HandleWorkflowProjectSecretsList(ctx context.Context, client *td.Client, ar
 		w.Flush()
 		fmt.Printf("\nTotal: %d secrets\n", len(resp.Secrets))
 	}
+	return nil
 }
 
-func HandleWorkflowProjectSecretsSet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowProjectSecretsSet sets a project secret.
+func HandleWorkflowProjectSecretsSet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		log.Fatal("Project ID, secret key, and secret value required")
+		return usageError("Project ID, secret key, and secret value required")
 	}
 
-	projectID := args[0]
-
-	err := client.Workflow.SetProjectSecret(ctx, projectID, args[1], args[2])
-	if err != nil {
-		HandleError(err, "Failed to set project secret", flags.Verbose)
+	if err := client.Workflow.SetProjectSecret(ctx, args[0], args[1], args[2]); err != nil {
+		return wrapError(err, "failed to set project secret", flags.Verbose)
 	}
 
-	fmt.Printf("Secret '%s' set successfully for project %s\n", args[1], projectID)
+	fmt.Printf("Secret '%s' set successfully for project %s\n", args[1], args[0])
+	return nil
 }
 
-func HandleWorkflowProjectSecretsDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowProjectSecretsDelete deletes a project secret.
+func HandleWorkflowProjectSecretsDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		log.Fatal("Project ID and secret key required")
+		return usageError("Project ID and secret key required")
 	}
 
-	projectID := args[0]
-
-	err := client.Workflow.DeleteProjectSecret(ctx, projectID, args[1])
-	if err != nil {
-		HandleError(err, "Failed to delete project secret", flags.Verbose)
+	if err := client.Workflow.DeleteProjectSecret(ctx, args[0], args[1]); err != nil {
+		return wrapError(err, "failed to delete project secret", flags.Verbose)
 	}
 
-	fmt.Printf("Secret '%s' deleted successfully from project %s\n", args[1], projectID)
+	fmt.Printf("Secret '%s' deleted successfully from project %s\n", args[1], args[0])
+	return nil
 }
 
-// Wrapper functions for test compatibility
-func handleWorkflowProjectList(ctx context.Context, client *td.Client, flags Flags) {
-	HandleWorkflowProjectList(ctx, client, flags)
+// Lowercase wrappers preserved for test ergonomics. They return errors so
+// tests can assert against them directly.
+func handleWorkflowProjectList(ctx context.Context, client *td.Client, flags Flags) error {
+	return HandleWorkflowProjectList(ctx, client, flags)
 }
 
-func handleWorkflowProjectGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	HandleWorkflowProjectGet(ctx, client, args, flags)
+func handleWorkflowProjectGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return HandleWorkflowProjectGet(ctx, client, args, flags)
 }
 
-func handleWorkflowProjectCreate(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	HandleWorkflowProjectCreate(ctx, client, args, flags)
+func handleWorkflowProjectCreate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return HandleWorkflowProjectCreate(ctx, client, args, flags)
 }
 
-func handleWorkflowProjectWorkflows(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	HandleWorkflowProjectWorkflows(ctx, client, args, flags)
+func handleWorkflowProjectWorkflows(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return HandleWorkflowProjectWorkflows(ctx, client, args, flags)
 }
 
-func handleWorkflowProjectSecretsList(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	HandleWorkflowProjectSecretsList(ctx, client, args, flags)
+func handleWorkflowProjectSecretsList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return HandleWorkflowProjectSecretsList(ctx, client, args, flags)
 }
 
-func handleWorkflowProjectSecretsSet(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	HandleWorkflowProjectSecretsSet(ctx, client, args, flags)
+func handleWorkflowProjectSecretsSet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return HandleWorkflowProjectSecretsSet(ctx, client, args, flags)
 }
 
-func handleWorkflowProjectSecretsDelete(ctx context.Context, client *td.Client, args []string, flags Flags) {
-	HandleWorkflowProjectSecretsDelete(ctx, client, args, flags)
+func handleWorkflowProjectSecretsDelete(ctx context.Context, client *td.Client, args []string, flags Flags) error {
+	return HandleWorkflowProjectSecretsDelete(ctx, client, args, flags)
 }
 
-func HandleWorkflowProjectDownload(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowProjectDownload downloads a project archive to disk.
+func HandleWorkflowProjectDownload(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Project ID or name required")
+		return usageError("Project ID or name required")
 	}
 
 	projectIdentifier := args[0]
 	var outputDir string
 
-	// Determine output directory
 	if len(args) >= 2 {
 		outputDir = args[1]
 	} else {
-		// Default to project name if available, otherwise use identifier
 		outputDir = projectIdentifier
 	}
 
-	// Revision support (we'll extend this with proper flag support later)
 	var revision string
 
 	if flags.Verbose {
@@ -311,48 +306,40 @@ func HandleWorkflowProjectDownload(ctx context.Context, client *td.Client, args 
 	var err error
 	var projectInfo *td.WorkflowProject
 
-	// Try to parse as project ID first (numeric)
 	_, parseErr := strconv.Atoi(projectIdentifier)
 	if parseErr == nil {
-		// It's a numeric ID, use it directly
 		if flags.Verbose {
 			fmt.Printf("Using project ID: %s\n", projectIdentifier)
 		}
 
-		// Get project info for display
 		projectInfo, err = client.Workflow.GetProject(ctx, projectIdentifier)
 		if err != nil {
-			HandleError(err, "Failed to get project details", flags.Verbose)
+			return wrapError(err, "failed to get project details", flags.Verbose)
 		}
 
-		// Download by ID
 		if revision != "" {
 			err = client.Workflow.DownloadProjectToDirectoryWithRevision(ctx, projectIdentifier, revision, outputDir)
 		} else {
 			err = client.Workflow.DownloadProjectToDirectory(ctx, projectIdentifier, outputDir)
 		}
 	} else {
-		// It's not numeric, try to find by name
 		if flags.Verbose {
 			fmt.Printf("Searching for project by name: %s\n", projectIdentifier)
 		}
 
-		// Get project by name using direct API call
 		projectInfo, err = client.Workflow.GetProjectByName(ctx, projectIdentifier)
 		if err != nil {
-			HandleError(err, "Failed to get project by name", flags.Verbose)
+			return wrapError(err, "failed to get project by name", flags.Verbose)
 		}
 
 		if flags.Verbose {
 			fmt.Printf("Found project: %s (ID: %s)\n", projectInfo.Name, projectInfo.ID)
 		}
 
-		// Use the project name for the default output directory if not specified
 		if len(args) < 2 {
 			outputDir = projectInfo.Name
 		}
 
-		// Download by name
 		if revision != "" {
 			err = client.Workflow.DownloadProjectByNameToDirectoryWithRevision(ctx, projectIdentifier, revision, outputDir)
 		} else {
@@ -361,7 +348,7 @@ func HandleWorkflowProjectDownload(ctx context.Context, client *td.Client, args 
 	}
 
 	if err != nil {
-		HandleError(err, "Failed to download project", flags.Verbose)
+		return wrapError(err, "failed to download project", flags.Verbose)
 	}
 
 	fmt.Printf("Project downloaded successfully\n")
@@ -372,12 +359,11 @@ func HandleWorkflowProjectDownload(ctx context.Context, client *td.Client, args 
 	}
 	fmt.Printf("Output directory: %s\n", outputDir)
 
-	// Show directory contents if verbose
 	if flags.Verbose {
 		fmt.Printf("\nExtracted files:\n")
 		err := filepath.Walk(outputDir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				return nil // Skip errors and continue
+				return nil
 			}
 			relPath, _ := filepath.Rel(outputDir, path)
 			if relPath == "." {
@@ -394,4 +380,5 @@ func HandleWorkflowProjectDownload(ctx context.Context, client *td.Client, args 
 			fmt.Printf("Warning: Failed to list extracted files: %v\n", err)
 		}
 	}
+	return nil
 }

--- a/cmd/tdcli/workflow/workflow_schedule.go
+++ b/cmd/tdcli/workflow/workflow_schedule.go
@@ -3,28 +3,25 @@ package workflow
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-// Workflow schedule handlers
-func HandleWorkflowScheduleGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowScheduleGet retrieves a workflow schedule.
+func HandleWorkflowScheduleGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Workflow ID required")
+		return usageError("Workflow ID required")
 	}
 
-	workflowID := args[0]
-
-	schedule, err := client.Workflow.GetWorkflowSchedule(ctx, workflowID)
+	schedule, err := client.Workflow.GetWorkflowSchedule(ctx, args[0])
 	if err != nil {
-		HandleError(err, "Failed to get workflow schedule", flags.Verbose)
+		return wrapError(err, "failed to get workflow schedule", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		PrintJSON(schedule)
+		return PrintJSON(schedule)
 	case "csv":
 		fmt.Println("id,workflow_id,cron,timezone,delay,next_time,disabled_at")
 		nextTime := ""
@@ -53,60 +50,60 @@ func HandleWorkflowScheduleGet(ctx context.Context, client *td.Client, args []st
 			fmt.Printf("Status: Enabled\n")
 		}
 	}
+	return nil
 }
 
-func HandleWorkflowScheduleEnable(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowScheduleEnable enables a workflow schedule.
+func HandleWorkflowScheduleEnable(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Workflow ID required")
+		return usageError("Workflow ID required")
 	}
 
-	workflowID := args[0]
-
-	schedule, err := client.Workflow.EnableWorkflowSchedule(ctx, workflowID)
+	schedule, err := client.Workflow.EnableWorkflowSchedule(ctx, args[0])
 	if err != nil {
-		HandleError(err, "Failed to enable workflow schedule", flags.Verbose)
+		return wrapError(err, "failed to enable workflow schedule", flags.Verbose)
 	}
 
 	fmt.Printf("Workflow schedule enabled successfully\n")
 	if schedule.NextTime != nil {
 		fmt.Printf("Next run: %s\n", schedule.NextTime.Format("2006-01-02 15:04:05"))
 	}
+	return nil
 }
 
-func HandleWorkflowScheduleDisable(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowScheduleDisable disables a workflow schedule.
+func HandleWorkflowScheduleDisable(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 1 {
-		log.Fatal("Workflow ID required")
+		return usageError("Workflow ID required")
 	}
 
-	workflowID := args[0]
-
-	_, err := client.Workflow.DisableWorkflowSchedule(ctx, workflowID)
-	if err != nil {
-		HandleError(err, "Failed to disable workflow schedule", flags.Verbose)
+	if _, err := client.Workflow.DisableWorkflowSchedule(ctx, args[0]); err != nil {
+		return wrapError(err, "failed to disable workflow schedule", flags.Verbose)
 	}
 
 	fmt.Printf("Workflow schedule disabled successfully\n")
+	return nil
 }
 
-func HandleWorkflowScheduleUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowScheduleUpdate updates a workflow schedule.
+func HandleWorkflowScheduleUpdate(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 4 {
-		log.Fatal("Workflow ID, cron expression, timezone, and delay required")
+		return usageError("Workflow ID, cron expression, timezone, and delay required")
 	}
-
-	workflowID := args[0]
 
 	delay, err := strconv.Atoi(args[3])
 	if err != nil {
-		log.Fatalf("Invalid delay: %s", args[3])
+		return usageError(fmt.Sprintf("Invalid delay: %s", args[3]))
 	}
 
-	schedule, err := client.Workflow.UpdateWorkflowSchedule(ctx, workflowID, args[1], args[2], delay)
+	schedule, err := client.Workflow.UpdateWorkflowSchedule(ctx, args[0], args[1], args[2], delay)
 	if err != nil {
-		HandleError(err, "Failed to update workflow schedule", flags.Verbose)
+		return wrapError(err, "failed to update workflow schedule", flags.Verbose)
 	}
 
 	fmt.Printf("Workflow schedule updated successfully\n")
 	fmt.Printf("Cron: %s\n", schedule.Cron)
 	fmt.Printf("Timezone: %s\n", schedule.Timezone)
 	fmt.Printf("Delay: %d seconds\n", schedule.Delay)
+	return nil
 }

--- a/cmd/tdcli/workflow/workflow_tasks.go
+++ b/cmd/tdcli/workflow/workflow_tasks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -12,24 +11,20 @@ import (
 	td "github.com/mickeey2525/treasuredata-go-sdk"
 )
 
-// Workflow task handlers
-func HandleWorkflowTaskList(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowTaskList lists tasks for a workflow attempt.
+func HandleWorkflowTaskList(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 2 {
-		log.Fatal("Workflow ID and attempt ID required")
+		return usageError("Workflow ID and attempt ID required")
 	}
 
-	workflowID := args[0]
-
-	attemptID := args[1]
-
-	resp, err := client.Workflow.ListWorkflowTasks(ctx, workflowID, attemptID)
+	resp, err := client.Workflow.ListWorkflowTasks(ctx, args[0], args[1])
 	if err != nil {
-		HandleError(err, "Failed to list workflow tasks", flags.Verbose)
+		return wrapError(err, "failed to list workflow tasks", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		PrintJSON(resp)
+		return PrintJSON(resp)
 	case "csv":
 		fmt.Println("id,full_name,state,is_group,started_at,updated_at")
 		for _, task := range resp.Tasks {
@@ -44,7 +39,7 @@ func HandleWorkflowTaskList(ctx context.Context, client *td.Client, args []strin
 	default:
 		if len(resp.Tasks) == 0 {
 			fmt.Println("No tasks found")
-			return
+			return nil
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
@@ -60,25 +55,23 @@ func HandleWorkflowTaskList(ctx context.Context, client *td.Client, args []strin
 		w.Flush()
 		fmt.Printf("\nTotal: %d tasks\n", len(resp.Tasks))
 	}
+	return nil
 }
 
-func HandleWorkflowTaskGet(ctx context.Context, client *td.Client, args []string, flags Flags) {
+// HandleWorkflowTaskGet retrieves a single workflow task.
+func HandleWorkflowTaskGet(ctx context.Context, client *td.Client, args []string, flags Flags) error {
 	if len(args) < 3 {
-		log.Fatal("Workflow ID, attempt ID, and task ID required")
+		return usageError("Workflow ID, attempt ID, and task ID required")
 	}
 
-	workflowID := args[0]
-
-	attemptID := args[1]
-
-	task, err := client.Workflow.GetWorkflowTask(ctx, workflowID, attemptID, args[2])
+	task, err := client.Workflow.GetWorkflowTask(ctx, args[0], args[1], args[2])
 	if err != nil {
-		HandleError(err, "Failed to get workflow task", flags.Verbose)
+		return wrapError(err, "failed to get workflow task", flags.Verbose)
 	}
 
 	switch flags.Format {
 	case "json":
-		PrintJSON(task)
+		return PrintJSON(task)
 	case "csv":
 		fmt.Println("id,full_name,state,is_group,started_at,updated_at")
 		startedAt := ""
@@ -109,4 +102,5 @@ func HandleWorkflowTaskGet(ctx context.Context, client *td.Client, args []string
 			fmt.Printf("  %s\n", configJSON)
 		}
 	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- Replace `handleError`/`handleUsageError` (which called `os.Exit` or relied on panic recovery) with idiomatic `error` returns from all CLI command handlers
- Remove `runHandlerWithErrorCapture` and `CaptureErrors` global variables
- Update `runInstrumented` to accept `func() error` instead of `func()`
- Add nil client checks to handler functions to prevent panics

## Test Plan
- All existing tests pass (`go test ./...`)
- Build and vet pass (`go build ./...`, `go vet ./...`)