### PR TITLE
fix: consolidate ldflags into single entry

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,10 +22,7 @@ builds:
       - goos: windows
         goarch: arm64
     ldflags:
-      - -s -w
-      - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
 
 archives:
   - id: tdcli


### PR DESCRIPTION
## Summary
- Consolidated goreleaser ldflags from 4 separate entries into a single entry
- Go's linker only honors the last `-ldflags` when multiple are passed, so the previous config only set `main.date`, leaving `version` as "dev" and `commit` as "unknown" in released binaries

## Root Cause
When passing multiple `-ldflags` arguments to `go build`, Go's linker silently ignores all but the last one. Each entry in goreleaser's `ldflags` list was being passed as a separate `-ldflags`, so only `-X main.date={{.Date}}` (the last entry) was applied.

## Fix
Combined all ldflags into one entry: `-s -w -X main.version=... -X main.commit=... -X main.date=...`